### PR TITLE
Enforce max players via ready client tracking

### DIFF
--- a/dotnet/KcdMp.Client/GameBridge.cs
+++ b/dotnet/KcdMp.Client/GameBridge.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net.Sockets;
@@ -34,6 +35,7 @@ public partial class GameBridge(ClientConfig config)
     private const float RotThreshold  = 0.02f;
 
     private IGameTransport _transport = null!;   // set in RunAsync before use
+    private readonly SemaphoreSlim _tcpWriteLock = new(1, 1);
 
     // Last pushed position (for change detection)
     private float _lastX, _lastY, _lastZ, _lastRotZ;
@@ -279,8 +281,8 @@ public partial class GameBridge(ClientConfig config)
     /// <summary>Game-seconds per real second (WO-38 live: ratio 15, confirmed exactly).</summary>
     private const double WorldTimeRatio = 15.0;
 
-    /// <summary>How often the mod is asked for the world clock (position-loop ticks; TickMs each).</summary>
-    private const int TimePollEveryTicks = 1000;   // ~10 s
+    /// <summary>How often the mod is asked for the world clock.</summary>
+    private static readonly TimeSpan TimePollInterval = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// How many game-seconds beyond the plausible natural advance between two
@@ -329,7 +331,7 @@ public partial class GameBridge(ClientConfig config)
     // minted per connection and a re-minted broadcast after reconnect would
     // duplicate the item on every peer that kept the old one.
     private readonly ConcurrentDictionary<uint, byte[]> _myOpenDrops = new();
-    private const int ItemDropHeartbeatEveryTicks = 3000;   // 30 s at TickMs=10
+    private static readonly TimeSpan ItemDropHeartbeatInterval = TimeSpan.FromSeconds(30);
 
     // Relay-assigned ghost id of THIS client, from the connect Ack. The
     // receive loop needs it to tell the mod whether an ItemClaimDown echo
@@ -366,19 +368,16 @@ public partial class GameBridge(ClientConfig config)
     // the ghost stays permanently bodiless -- observed live: the nameplate kept
     // walking its path with nothing under it. Re-verified on the same slow
     // cadence as the interp re-arm; see the position loop.
-    private const int ReconcileGhostsEveryTicks = 500;
+    private static readonly TimeSpan ReconcileGhostsInterval = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// How often the position loop re-arms the mod's Script.SetTimer loops.
-    /// The loop runs at roughly the emit interval, so a few hundred ticks is
-    /// a handful of seconds -- fast enough that a save load costs at most a
-    /// brief freeze, slow enough to be free.
     /// </summary>
-    private const int ReArmInterpEveryTicks = 250;
+    private static readonly TimeSpan ReArmInterpInterval = TimeSpan.FromMilliseconds(2500);
 
     /// <summary>
     /// WO-59: how often the last position is re-sent even when the player has
-    /// not moved (200 ticks x 10 ms = 2 s). Positions were purely
+    /// not moved (every 2 s). Positions were purely
     /// change-gated, which left a standing-still player unspawnable on any
     /// peer whose reload had just cleared the ghost row -- WO-38's
     /// "invisible after reload" candidate (a), now closed: Reconcile clears
@@ -386,7 +385,9 @@ public partial class GameBridge(ClientConfig config)
     /// trigger within 2 s more, moving or not. One 18-byte packet per 2 s
     /// of stillness is the whole cost.
     /// </summary>
-    private const int PositionHeartbeatEveryTicks = 200;
+    private static readonly TimeSpan PositionHeartbeatInterval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan AggroSweepInterval = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan WeatherTickInterval = TimeSpan.FromSeconds(5);
     // Reassigned per connection, same idiom as _combat.OnLocalHit: closes
     // over that connection's stream, so callers that don't have it
     // themselves (OnGameEvent, the tail transport's own event thread) can
@@ -720,7 +721,7 @@ public partial class GameBridge(ClientConfig config)
             pkt[0] = type;
             BinaryPrimitives.WriteUInt16LittleEndian(pkt.AsSpan(1), (ushort)payload.Length);
             payload.CopyTo(pkt, 3);
-            await stream.WriteAsync(pkt, ict);
+            await WritePacketAsync(stream, pkt, ict);
         }
 
         var interactions = new InteractionClient(SendPacketAsync);
@@ -909,6 +910,14 @@ public partial class GameBridge(ClientConfig config)
         {
             int tickCount = 0;
             long totalReadMs = 0;
+            long nowTimestamp = Stopwatch.GetTimestamp();
+            long lastReArm = nowTimestamp;
+            long lastDropHeartbeat = nowTimestamp;
+            long lastGhostReconcile = nowTimestamp;
+            long lastAggroSweep = nowTimestamp;
+            long lastTimePoll = nowTimestamp;
+            long lastWeatherTick = nowTimestamp;
+            long lastPositionHeartbeat = nowTimestamp;
 
             while (tcp.Connected)
             {
@@ -917,6 +926,7 @@ public partial class GameBridge(ClientConfig config)
                 sw.Stop();
                 totalReadMs += sw.ElapsedMilliseconds;
                 tickCount++;
+                nowTimestamp = Stopwatch.GetTimestamp();
 
                 // Re-arm the mod's own timer loops periodically (WO-13).
                 // Loading a save destroys every pending Script.SetTimer in the
@@ -927,7 +937,7 @@ public partial class GameBridge(ClientConfig config)
                 // load. StartInterp is idempotent and cheap (a stamp
                 // comparison) so calling it on a slow cadence costs nothing
                 // and makes the recovery automatic rather than a restart.
-                if (tickCount % ReArmInterpEveryTicks == 0)
+                if (IntervalElapsed(ref lastReArm, ReArmInterpInterval, nowTimestamp))
                 {
                     // WO-28 Phase 0 found this was only half a fix. WO-13
                     // re-armed the interp loop and stopped there, but a save
@@ -987,7 +997,8 @@ public partial class GameBridge(ClientConfig config)
                 // WO-48: re-broadcast my still-unclaimed drops so a peer who
                 // joined after the drop still converges. Receivers dedupe by
                 // dropId, so a resend costs nothing when everyone has it.
-                if (tickCount % ItemDropHeartbeatEveryTicks == 0 && !_myOpenDrops.IsEmpty)
+                if (IntervalElapsed(ref lastDropHeartbeat, ItemDropHeartbeatInterval, nowTimestamp)
+                    && !_myOpenDrops.IsEmpty)
                 {
                     foreach (var payload in _myOpenDrops.Values)
                         try { await SendItemDropAsync(stream, payload, cts.Token); } catch { }
@@ -1000,14 +1011,14 @@ public partial class GameBridge(ClientConfig config)
                 // path with no body under it, indefinitely. The mod cannot
                 // notice on its own without paying a world lookup on the hot
                 // 20 ms path, so it is asked on a slow cadence from here.
-                if (tickCount % ReconcileGhostsEveryTicks == 0)
+                if (IntervalElapsed(ref lastGhostReconcile, ReconcileGhostsInterval, nowTimestamp))
                 {
                     try { await ExecLuaAsync("if KCD2MP_ReconcileGhosts then KCD2MP_ReconcileGhosts() end"); }
                     catch { }
                 }
 
                 // WO-17: cheap when nothing is attached -- see the method doc.
-                if (tickCount % 100 == 0)
+                if (IntervalElapsed(ref lastAggroSweep, AggroSweepInterval, nowTimestamp))
                     _ = SweepAggroCooldownsAsync(cts.Token);
 
                 // WO-38 Phase 1: poll the world clock on a slow cadence. Feeds
@@ -1016,7 +1027,8 @@ public partial class GameBridge(ClientConfig config)
                 // event, handled in OnGameEvent. One batched Lua call per
                 // ~10 s; suppressed while our own marker-skip is resolving,
                 // since the skip-end path requests the same reading itself.
-                if (tickCount % TimePollEveryTicks == 0 && !_localSkipActive && !_awaitSkipDoneTime)
+                if (IntervalElapsed(ref lastTimePoll, TimePollInterval, nowTimestamp)
+                    && !_localSkipActive && !_awaitSkipDoneTime)
                 {
                     try { await ExecLuaAsync("if KCD2MP_ReportWorldTime then KCD2MP_ReportWorldTime() end"); }
                     catch { }
@@ -1025,7 +1037,7 @@ public partial class GameBridge(ClientConfig config)
                 // WO-40 Phase 3: weather arbitration, checked every ~5 s.
                 // All the real gates (authority, live peers, cadences) live
                 // inside the tick.
-                if (tickCount % 500 == 0)
+                if (IntervalElapsed(ref lastWeatherTick, WeatherTickInterval, nowTimestamp))
                     WeatherArbiterTick();
 
                 if (state.HasValue)
@@ -1048,7 +1060,8 @@ public partial class GameBridge(ClientConfig config)
                         _voice.UpdateAllVolumes();
                     }
 
-                    bool posHeartbeat = tickCount % PositionHeartbeatEveryTicks == 0;
+                    bool posHeartbeat = IntervalElapsed(
+                        ref lastPositionHeartbeat, PositionHeartbeatInterval, nowTimestamp);
                     if (!_hasPushed || HasChanged(x, y, z, rotZ) || posHeartbeat)
                     {
                         bool moved = !_hasPushed || HasChanged(x, y, z, rotZ);
@@ -1154,7 +1167,7 @@ public partial class GameBridge(ClientConfig config)
                 packet[0] = Protocol.Ping;
                 BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), 8);
                 tsBytes.CopyTo(packet, 3);
-                await stream.WriteAsync(packet, ct);
+                await WritePacketAsync(stream, packet, ct);
             }
             catch (OperationCanceledException) { break; }
             catch { break; }
@@ -1185,8 +1198,8 @@ public partial class GameBridge(ClientConfig config)
     /// </summary>
     private async Task AppearanceLoopAsync(NetworkStream stream, CancellationToken ct)
     {
-        int ticksSinceSend = int.MaxValue; // force the first poll to send
-        int ticksPerHeartbeat = Math.Max(1, Protocol.AppearanceHeartbeatSeconds * 1000 / AppearancePollMs);
+        long lastSentTimestamp = 0; // zero forces the first successful poll to send
+        var heartbeatInterval = TimeSpan.FromSeconds(Protocol.AppearanceHeartbeatSeconds);
 
         while (!ct.IsCancellationRequested)
         {
@@ -1216,7 +1229,8 @@ public partial class GameBridge(ClientConfig config)
                     }
                     var currentSet = new HashSet<Guid>(current);
                     bool changed = _lastSentAppearance is null || !currentSet.SetEquals(_lastSentAppearance);
-                    bool heartbeatDue = ticksSinceSend >= ticksPerHeartbeat;
+                    bool heartbeatDue = lastSentTimestamp == 0
+                        || Stopwatch.GetElapsedTime(lastSentTimestamp) >= heartbeatInterval;
                     bool forced = _forceAppearanceResync;
 
                     if (changed || heartbeatDue || forced)
@@ -1226,7 +1240,7 @@ public partial class GameBridge(ClientConfig config)
                             : currentSet.Take(Protocol.MaxAppearanceItems).ToArray();
                         await SendAppearanceAsync(stream, items, ct);
                         _lastSentAppearance = currentSet;
-                        ticksSinceSend = 0;
+                        lastSentTimestamp = Stopwatch.GetTimestamp();
                         _forceAppearanceResync = false;
                         Console.WriteLine($"[appearance] sent {items.Length} item class(es)" +
                             (forced ? " (forced)" : changed ? "" : " (heartbeat)"));
@@ -1237,7 +1251,6 @@ public partial class GameBridge(ClientConfig config)
 
             try { await Task.Delay(AppearancePollMs, ct); }
             catch (OperationCanceledException) { break; }
-            ticksSinceSend++;
         }
     }
 
@@ -1642,7 +1655,7 @@ public partial class GameBridge(ClientConfig config)
             packet[0] = Protocol.PauseUp;
             BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), Protocol.PauseUpPayloadLen);
             packet[3] = aggregate ? Protocol.PauseStateEntered : Protocol.PauseStateExited;
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             Console.WriteLine($"[pause] local state -> {(aggregate ? "entered" : "exited")}");
         }
         catch (Exception ex) { Console.WriteLine($"[pause] send failed: {ex.Message}"); }
@@ -1664,7 +1677,7 @@ public partial class GameBridge(ClientConfig config)
             packet[3] = phase;
             packet[4] = kind;
             BinaryPrimitives.WriteUInt32LittleEndian(packet.AsSpan(5), worldTime);
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             Console.WriteLine($"[timeskip] sent {phase switch { Protocol.TimeSkipPhaseStart => "start", Protocol.TimeSkipPhaseSync => "sync", _ => "done" }} kind={kind} t={worldTime}");
         }
         catch (Exception ex) { Console.WriteLine($"[timeskip] send failed: {ex.Message}"); }
@@ -1847,7 +1860,7 @@ public partial class GameBridge(ClientConfig config)
             BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), (ushort)(1 + nameBytes.Length));
             packet[3] = (byte)nameBytes.Length;
             nameBytes.CopyTo(packet, 4);
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             Console.WriteLine($"[horse] sent mount identity '{(horseName.Length == 0 ? "(none)" : horseName)}'");
         }
         catch (Exception ex) { Console.WriteLine($"[horse] send failed: {ex.Message}"); }
@@ -1866,7 +1879,7 @@ public partial class GameBridge(ClientConfig config)
             packet[0] = Protocol.CombatEventUp;
             BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), Protocol.CombatEventUpPayloadLen);
             packet[3] = evt;
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
         }
         catch (Exception ex) { Console.WriteLine($"[combatviz] send failed: {ex.Message}"); }
     }
@@ -1935,7 +1948,7 @@ public partial class GameBridge(ClientConfig config)
             packet[0] = Protocol.ItemDropUp;
             BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), (ushort)payload.Length);
             payload.CopyTo(packet, 3);
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
         }
         catch (Exception ex) { Console.WriteLine($"[itemsync] drop send failed: {ex.Message}"); }
     }
@@ -1949,7 +1962,7 @@ public partial class GameBridge(ClientConfig config)
             packet[0] = Protocol.ItemClaimUp;
             BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), Protocol.ItemClaimUpPayloadLen);
             BinaryPrimitives.WriteUInt32LittleEndian(packet.AsSpan(3), dropId);
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             Console.WriteLine($"[itemsync] sent claim for drop {dropId}");
         }
         catch (Exception ex) { Console.WriteLine($"[itemsync] claim send failed: {ex.Message}"); }
@@ -1971,7 +1984,7 @@ public partial class GameBridge(ClientConfig config)
             packet[3] = (byte)nameBytes.Length;
             nameBytes.CopyTo(packet, 4);
             BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(4 + nameBytes.Length), blendSec);
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             Console.WriteLine($"[weather] sent profile '{profile}' blend={blendSec}");
         }
         catch (Exception ex) { Console.WriteLine($"[weather] send failed: {ex.Message}"); }
@@ -2218,7 +2231,7 @@ public partial class GameBridge(ClientConfig config)
         packet[11] = flags;
         try
         {
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             if (changed)
                 Console.WriteLine($"[vitals] sent health={health:F1} stamina={stamina:F1} flags={flags}");
             _lastSentHealth = health;
@@ -2264,7 +2277,7 @@ public partial class GameBridge(ClientConfig config)
         BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), Protocol.PlayerDeathUpPayloadLen);
         try
         {
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             Console.WriteLine("[death] local player died -- told the relay");
         }
         catch (Exception ex)
@@ -2332,7 +2345,7 @@ public partial class GameBridge(ClientConfig config)
         BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(o + 12), rotZ);
         BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(o + 16), health);
         packet[o + 20] = flags;
-        try { await stream.WriteAsync(packet, ct); }
+        try { await WritePacketAsync(stream, packet, ct); }
         catch (Exception ex) { Console.WriteLine($"[npcsync] send failed: {ex.Message}"); }
     }
 
@@ -2355,7 +2368,7 @@ public partial class GameBridge(ClientConfig config)
         packet[12] = 0;
         try
         {
-            await stream.WriteAsync(packet, ct);
+            await WritePacketAsync(stream, packet, ct);
             Console.WriteLine($"[playerhit] ghost {targetGhostId} lost {healthLoss:F1} here -- told its owner");
         }
         catch (Exception ex) { Console.WriteLine($"[playerhit] send failed: {ex.Message}"); }
@@ -2425,7 +2438,7 @@ public partial class GameBridge(ClientConfig config)
         catch (Exception ex) { Console.WriteLine($"[role] could not tell the mod: {ex.Message}"); }
     }
 
-    private static async Task SendAppearanceAsync(NetworkStream stream, Guid[] itemClasses, CancellationToken ct)
+    private async Task SendAppearanceAsync(NetworkStream stream, Guid[] itemClasses, CancellationToken ct)
     {
         int payloadLen = 1 + itemClasses.Length * Protocol.ItemClassLen;
         var packet = new byte[3 + payloadLen];
@@ -2438,7 +2451,7 @@ public partial class GameBridge(ClientConfig config)
             cls.TryWriteBytes(packet.AsSpan(o, Protocol.ItemClassLen));
             o += Protocol.ItemClassLen;
         }
-        await stream.WriteAsync(packet, ct);
+        await WritePacketAsync(stream, packet, ct);
     }
 
     // -------------------------------------------------------------------------
@@ -3626,7 +3639,7 @@ public partial class GameBridge(ClientConfig config)
     /// will bounce the same hit back and forth forever. That is why applying
     /// remote damage goes straight to the pipe and never through here.
     /// </summary>
-    public static async Task SendLocalHitAsync(NetworkStream stream, Guid soul,
+    public async Task SendLocalHitAsync(NetworkStream stream, Guid soul,
                                                float stamina, float health,
                                                bool suppressHitReaction)
     {
@@ -3637,7 +3650,7 @@ public partial class GameBridge(ClientConfig config)
         BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(19), stamina);
         BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(23), health);
         packet[27] = suppressHitReaction ? Protocol.DamageFlagSuppressHitReaction : (byte)0;
-        await stream.WriteAsync(packet);
+        await WritePacketAsync(stream, packet);
     }
 
     /// <summary>
@@ -3645,7 +3658,7 @@ public partial class GameBridge(ClientConfig config)
     /// cross-install-reliable alternative to guid-addressed 0x12. The caller
     /// has already translated the local per-save guid to the soul's name.
     /// </summary>
-    public static async Task SendNpcDamageAsync(NetworkStream stream, string npcName,
+    public async Task SendNpcDamageAsync(NetworkStream stream, string npcName,
                                                 float stamina, float health,
                                                 bool suppressHitReaction)
     {
@@ -3659,30 +3672,30 @@ public partial class GameBridge(ClientConfig config)
         BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(o), stamina);
         BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(o + 4), health);
         packet[o + 8] = suppressHitReaction ? Protocol.DamageFlagSuppressHitReaction : (byte)0;
-        await stream.WriteAsync(packet);
+        await WritePacketAsync(stream, packet);
     }
 
     /// <summary>Report an NPC our client killed. Idempotent at every receiver.</summary>
-    public static async Task SendLocalDeathAsync(NetworkStream stream, Guid soul)
+    public async Task SendLocalDeathAsync(NetworkStream stream, Guid soul)
     {
         var packet = new byte[3 + Protocol.DeathUpPayloadLen];
         packet[0] = Protocol.DeathUp;
         BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), Protocol.DeathUpPayloadLen);
         soul.TryWriteBytes(packet.AsSpan(3, 16));
-        await stream.WriteAsync(packet);
+        await WritePacketAsync(stream, packet);
     }
 
-    private static async Task SendVoiceAsync(NetworkStream stream, byte[] pcm)
+    private async Task SendVoiceAsync(NetworkStream stream, byte[] pcm)
     {
         // 3 header + 640 payload = 643 bytes
         var packet = new byte[3 + Protocol.VoiceFrameLen];
         packet[0] = Protocol.VoiceUp;
         BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), Protocol.VoiceFrameLen);
         Buffer.BlockCopy(pcm, 0, packet, 3, Protocol.VoiceFrameLen);
-        await stream.WriteAsync(packet);
+        await WritePacketAsync(stream, packet);
     }
 
-    private static async Task SendPositionAsync(NetworkStream stream, float x, float y, float z, float rotZ, bool isRiding)
+    private async Task SendPositionAsync(NetworkStream stream, float x, float y, float z, float rotZ, bool isRiding)
     {
         // 3 header + 17 payload = 20 bytes
         var packet = new byte[3 + Protocol.PositionPayloadLen];
@@ -3693,7 +3706,21 @@ public partial class GameBridge(ClientConfig config)
         WriteFloat(packet, 11, z);
         WriteFloat(packet, 15, rotZ);
         packet[19] = isRiding ? (byte)0x01 : (byte)0x00;
-        await stream.WriteAsync(packet);
+        await WritePacketAsync(stream, packet);
+    }
+
+    private async Task WritePacketAsync(NetworkStream stream, byte[] packet, CancellationToken ct = default)
+    {
+        await _tcpWriteLock.WaitAsync(ct);
+        try { await stream.WriteAsync(packet, ct); }
+        finally { _tcpWriteLock.Release(); }
+    }
+
+    private static bool IntervalElapsed(ref long lastTimestamp, TimeSpan interval, long nowTimestamp)
+    {
+        if (Stopwatch.GetElapsedTime(lastTimestamp, nowTimestamp) < interval) return false;
+        lastTimestamp = nowTimestamp;
+        return true;
     }
 
     private static float ReadFloat(byte[] buf, int offset) =>

--- a/dotnet/KcdMp.Server/Features/ClientHandling/ClientHandler.cs
+++ b/dotnet/KcdMp.Server/Features/ClientHandling/ClientHandler.cs
@@ -10,7 +10,9 @@ namespace KcdMp.Server.Features.ClientHandling;
 public class ClientHandler
 {
 	private readonly List<ClientSession> _clients = [];
+	private readonly HashSet<ClientSession> _readyClients = [];
 	private readonly object _lock = new();
+	private readonly int _maxPlayers;
 
 	// ---- WO-66 claim-update validation tunables ----
 	//
@@ -28,6 +30,7 @@ public class ClientHandler
 
 	public ClientHandler(IConfiguration configuration)
 	{
+		_maxPlayers          = configuration.GetValue("ServerInfo:MaxPlayers", 64);
 		_maxNpcSpeedMps      = configuration.GetValue("NpcClaimValidation:MaxSpeedMps", 40.0);
 		_npcSpeedSlackMeters = configuration.GetValue("NpcClaimValidation:SlackMeters", 2.0);
 	}
@@ -45,6 +48,22 @@ public class ClientHandler
 	}
 
 	/// <summary>
+	/// Reserves one player slot after a valid handshake. The check and reserve
+	/// happen under the same lock so simultaneous handshakes cannot overbook
+	/// the relay; a socket that never handshakes consumes no player slot.
+	/// </summary>
+	public bool TryMarkReady(ClientSession client)
+	{
+		lock (_lock)
+		{
+			if (_readyClients.Count >= _maxPlayers)
+				return false;
+
+			return _readyClients.Add(client);
+		}
+	}
+
+	/// <summary>
 	/// Remove a client.
 	///
 	/// Called when a client disconnects.
@@ -53,7 +72,10 @@ public class ClientHandler
 	public void RemoveClient(ClientSession client)
 	{
 		lock (_lock)
+		{
 			_clients.Remove(client);
+			_readyClients.Remove(client);
+		}
 	}
 
 	/// <summary>
@@ -412,12 +434,7 @@ public class ClientHandler
 		get
 		{
 			lock (_lock)
-			{
-				int count = 0;
-				foreach (var c in _clients)
-					if (c.IsReady) count++;
-				return count;
-			}
+				return _readyClients.Count;
 		}
 	}
 }

--- a/dotnet/KcdMp.Server/Features/ClientHandling/ClientSession.cs
+++ b/dotnet/KcdMp.Server/Features/ClientHandling/ClientSession.cs
@@ -1,7 +1,6 @@
 using System.Buffers.Binary;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Channels;
 using KcdMp.Server.Features.Interactions;
 using KcdMp.Server.Features.Tcp;
 using ILogger = Serilog.ILogger;
@@ -23,7 +22,14 @@ public class ClientSession
     private readonly TcpBroadcastService _broadcastService;
     private readonly SessionManager _sessions;
     private readonly ClientHandler _clientHandler;
-    private readonly Channel<byte[]> _writeQueue = Channel.CreateUnbounded<byte[]>();
+    private const int MaxQueuedPackets = 512;
+    private readonly object _writeQueueLock = new();
+    private readonly Queue<QueuedWrite> _writeQueue = new();
+    private readonly Dictionary<byte, byte[]> _pendingGhostPackets = new();
+    private readonly SemaphoreSlim _writeSignal = new(0);
+    private bool _writeQueueStopped;
+
+    private readonly record struct QueuedWrite(byte[]? Packet, byte? GhostId);
 
     public byte Id { get; } = (byte)Interlocked.Increment(ref _idCounter);
     public string? Name { get; private set; }
@@ -484,13 +490,13 @@ public class ClientSession
                 _broadcastService.Broadcast(this, x, y, z, rotZ, flags);
             }
         }
-        catch (Exception ex) when (ex is IOException or SocketException or EndOfStreamException)
+        catch (Exception ex) when (ex is IOException or SocketException or EndOfStreamException or ObjectDisposedException)
         {
             // Normal disconnect
         }
         finally
         {
-            _writeQueue.Writer.Complete();
+            StopWriteQueue();
             await writeTask;
             _tcp.Dispose();
         }
@@ -506,7 +512,7 @@ public class ClientSession
         WriteFloat(payload, 9, z);
         WriteFloat(payload, 13, rotZ);
         payload[17] = flags;
-        EnqueueRaw(BuildPacket(Protocol.Ghost, payload));
+        EnqueueGhostPacket(ghostId, BuildPacket(Protocol.Ghost, payload));
     }
 
     /// <summary>Thread-safe: enqueue a Disconnect packet (0x06) to be sent to this client.</summary>
@@ -886,13 +892,100 @@ public class ClientSession
         EnqueueRaw(BuildPacket(Protocol.ReleaseVersion, payload));
     }
 
-    private void EnqueueRaw(byte[] packet) =>
-        _writeQueue.Writer.TryWrite(packet);
+    private void EnqueueRaw(byte[] packet)
+    {
+        bool overflow;
+        lock (_writeQueueLock)
+        {
+            if (_writeQueueStopped) return;
+            overflow = _writeQueue.Count >= MaxQueuedPackets;
+            if (!overflow) _writeQueue.Enqueue(new(packet, null));
+        }
+
+        if (overflow) AbortWriteQueue("outbound queue limit reached");
+        else _writeSignal.Release();
+    }
+
+    private void EnqueueGhostPacket(byte ghostId, byte[] packet)
+    {
+        bool overflow;
+        bool queued = false;
+        lock (_writeQueueLock)
+        {
+            if (_writeQueueStopped) return;
+
+            if (_pendingGhostPackets.ContainsKey(ghostId))
+            {
+                // A marker for this source is already queued. Replace only its
+                // payload so a slow client receives the newest position.
+                _pendingGhostPackets[ghostId] = packet;
+                return;
+            }
+
+            overflow = _writeQueue.Count >= MaxQueuedPackets;
+            if (!overflow)
+            {
+                _pendingGhostPackets[ghostId] = packet;
+                _writeQueue.Enqueue(new(null, ghostId));
+                queued = true;
+            }
+        }
+
+        if (overflow) AbortWriteQueue("outbound queue limit reached");
+        else if (queued) _writeSignal.Release();
+    }
+
+    private void StopWriteQueue()
+    {
+        lock (_writeQueueLock) _writeQueueStopped = true;
+        _writeSignal.Release();
+    }
+
+    private void AbortWriteQueue(string? reason)
+    {
+        lock (_writeQueueLock)
+        {
+            if (_writeQueueStopped) return;
+            _writeQueueStopped = true;
+            _writeQueue.Clear();
+            _pendingGhostPackets.Clear();
+        }
+
+        if (reason is not null)
+            _logger.Warning("[!] Disconnecting {Name}: {Reason}.", Name ?? $"id={Id}", reason);
+        _writeSignal.Release();
+        _tcp.Dispose();
+    }
 
     private async Task WriteLoopAsync()
     {
-        await foreach (var packet in _writeQueue.Reader.ReadAllAsync())
+        while (true)
         {
+            await _writeSignal.WaitAsync();
+
+            byte[]? packet = null;
+            lock (_writeQueueLock)
+            {
+                if (_writeQueue.Count > 0)
+                {
+                    var queued = _writeQueue.Dequeue();
+                    if (queued.GhostId is byte ghostId)
+                    {
+                        _pendingGhostPackets.Remove(ghostId, out packet);
+                    }
+                    else
+                    {
+                        packet = queued.Packet;
+                    }
+                }
+                else if (_writeQueueStopped)
+                {
+                    return;
+                }
+            }
+
+            if (packet is null) continue;
+
             try { await _stream.WriteAsync(packet); }
             catch (Exception ex)
             {
@@ -903,6 +996,7 @@ public class ClientSession
                 // unexpected write failure (not just "the peer is gone") used
                 // to be indistinguishable from a normal disconnect from here.
                 _logger.Debug(ex, "[!] Write loop for {Name} stopped", Name ?? $"id={Id}");
+                AbortWriteQueue(null);
                 break;
             }
         }

--- a/dotnet/KcdMp.Server/Features/ClientHandling/ClientSession.cs
+++ b/dotnet/KcdMp.Server/Features/ClientHandling/ClientSession.cs
@@ -89,7 +89,7 @@ public class ClientSession
                     nameLen, handshakeLen - 2);
                 return;
             }
-            Name = Encoding.UTF8.GetString(handshakePayload, 2, nameLen);
+            string name = Encoding.UTF8.GetString(handshakePayload, 2, nameLen);
 
             // WO-19: an optional trailing release-version field, the same
             // idiom as Invite's [configLen][config] -- whatever is left after
@@ -98,6 +98,15 @@ public class ClientSession
             int releaseVersionOffset = 2 + nameLen;
             if (handshakeLen > releaseVersionOffset)
                 ReleaseVersion = Encoding.UTF8.GetString(handshakePayload, releaseVersionOffset, handshakeLen - releaseVersionOffset);
+
+            if (!_clientHandler.TryMarkReady(this))
+            {
+                _logger.Warning("[!] Rejecting '{Name}' from {ClientRemoteEndPoint}: server is full.",
+                    name, _tcp.Client.RemoteEndPoint);
+                return;
+            }
+
+            Name = name;
 
             _logger.Information("[+] '{Name}' connected (id={Id}, protocol v{Version}, release {Release}) from {ClientRemoteEndPoint}.",
                 Name, Id, clientVersion, ReleaseVersion ?? "(none)", _tcp.Client.RemoteEndPoint);

--- a/dotnet/KcdMp.Server/Features/ServerInformation/Controllers/InformationController.cs
+++ b/dotnet/KcdMp.Server/Features/ServerInformation/Controllers/InformationController.cs
@@ -33,7 +33,7 @@ public class InformationController : ControllerBase
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	public IActionResult GetInfo()
 	{
-		_serverInfo.Players = _clientHandler.ClientCount;
+		_serverInfo.Players = _clientHandler.ReadyClientCount;
 
 		return Ok(_serverInfo);
 	}

--- a/native/KCDMP/dllmain.cpp
+++ b/native/KCDMP/dllmain.cpp
@@ -161,9 +161,6 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID) {
     if (reason == DLL_PROCESS_ATTACH) {
         DisableThreadLibraryCalls(module);
         CloseHandle(CreateThread(nullptr, 0, plugin_main, nullptr, 0, nullptr));
-    } else if (reason == DLL_PROCESS_DETACH) {
-        kcdmp::pipe::stop();
-        kcdmp::main_thread::uninstall();
     }
     return TRUE;
 }

--- a/native/KCDMP/main_thread.cpp
+++ b/native/KCDMP/main_thread.cpp
@@ -3,8 +3,10 @@
 #include "log.h"
 
 #include <windows.h>
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -25,12 +27,13 @@ std::mutex                          g_mutex;
 std::vector<std::function<void()>>  g_queue;
 std::vector<std::function<void()>>  g_repeating;
 std::condition_variable             g_drained;
-volatile unsigned long long         g_frames = 0;
+std::atomic<unsigned long long>     g_frames{0};
 DWORD                               g_main_thread_id = 0;
 
 constexpr const char* kImporter = "WHGame.dll";
 constexpr const char* kProvider = "Framework.dll";
 constexpr const char* kSymbol   = "?Update@C_ModulesManager@framework@wh@@QEAAXM@Z";
+enum class SyncPhase { pending, running, done, cancelled };
 
 // Separate function because __try/__except cannot share a frame with objects
 // that need unwinding (C2712), and the drain loop below owns a vector of
@@ -127,23 +130,60 @@ bool run_sync(std::function<void()> work, unsigned timeout_ms) {
         return true;
     }
 
-    std::mutex done_mutex;
-    std::condition_variable done_cv;
-    bool done = false;
+    struct State {
+        std::mutex mutex;
+        std::condition_variable cv;
+        std::function<void()> work;
+        SyncPhase phase = SyncPhase::pending;
+    };
 
-    post([&] {
-        work();
+    auto state = std::make_shared<State>();
+    state->work = std::move(work);
+
+    post([state] {
         {
-            std::lock_guard<std::mutex> lock(done_mutex);
-            done = true;
+            std::lock_guard<std::mutex> lock(state->mutex);
+            if (state->phase != SyncPhase::pending) return;
+            state->phase = SyncPhase::running;
         }
-        done_cv.notify_all();
+
+        // Guard here as well as in hooked_update so an SEH fault cannot skip
+        // the completion signal and leave the waiting pipe thread blocked.
+        try {
+            run_guarded(&state->work);
+        } catch (...) {
+            logf("MAIN: task raised a C++ exception -- swallowed");
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->work = {};
+            state->phase = SyncPhase::done;
+        }
+        state->cv.notify_all();
     });
 
-    std::unique_lock<std::mutex> lock(done_mutex);
-    return done_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&] { return done; });
+    std::unique_lock<std::mutex> lock(state->mutex);
+    if (state->cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&] {
+            return state->phase == SyncPhase::done;
+        })) {
+        return true;
+    }
+
+    if (state->phase == SyncPhase::pending) {
+        // The frame never picked the task up. Cancel it while its captured
+        // caller state is still alive; the queued wrapper becomes a no-op.
+        state->phase = SyncPhase::cancelled;
+        state->work = {};
+        return false;
+    }
+
+    // Once execution has started, returning would invalidate references held
+    // by the caller's lambda. Finish safely even if that crosses the timeout.
+    state->cv.wait(lock, [&] { return state->phase == SyncPhase::done; });
+    return true;
 }
 
-unsigned long long frame_count() { return g_frames; }
+unsigned long long frame_count() { return g_frames.load(std::memory_order_relaxed); }
 
 } // namespace kcdmp::main_thread

--- a/native/KCDMP/main_thread.h
+++ b/native/KCDMP/main_thread.h
@@ -28,8 +28,9 @@ void post(std::function<void()> work);
 // outbound sampler, which needs a per-frame heartbeat rather than a one-shot.
 void post_repeating(std::function<void()> work);
 
-// Queue work and block until it has run, up to timeout_ms. Returns false on
-// timeout -- which means the tick is not running, not that the work failed.
+// Queue work and block until it has run. Returns false when timeout_ms elapses
+// before the game thread starts it. Work already running is allowed to finish
+// so lambdas capturing caller state cannot outlive that state.
 bool run_sync(std::function<void()> work, unsigned timeout_ms = 5000);
 
 // Frames observed since install. Zero after a second or two means the hook is

--- a/native/KCDMP/pipe_server.cpp
+++ b/native/KCDMP/pipe_server.cpp
@@ -20,7 +20,6 @@ constexpr const char* kPipeName = R"(\\.\pipe\kcdmp)";
 std::atomic<bool>   g_running{false};
 std::atomic<bool>   g_connected{false};
 HANDLE              g_pipe = INVALID_HANDLE_VALUE;
-std::thread         g_thread;
 uint8_t             g_seq = 0;
 
 // The pipe is duplex and both directions are in use at once: the serve loop
@@ -366,7 +365,9 @@ bool start() {
         rttr::sample_health(&send_local_hit);
     });
 
-    g_thread = std::thread(listen_loop);
+    // The injected plugin has process lifetime. Detaching keeps DLL teardown
+    // free of a blocking join under the Windows loader lock.
+    std::thread(listen_loop).detach();
     logf("PIPE: listening on %s", kPipeName);
     return true;
 }
@@ -377,7 +378,6 @@ void stop() {
     HANDLE poke = CreateFileA(kPipeName, GENERIC_READ | GENERIC_WRITE, 0, nullptr,
                               OPEN_EXISTING, 0, nullptr);
     if (poke != INVALID_HANDLE_VALUE) CloseHandle(poke);
-    if (g_thread.joinable()) g_thread.join();
 }
 
 bool connected() { return g_connected; }

--- a/tools/Test-NpcClaimValidation.ps1
+++ b/tools/Test-NpcClaimValidation.ps1
@@ -31,6 +31,9 @@
                              self-heal for a genuine teleport).
       V6  counters        -> GET api/information/npc-validation matches the
                              exact per-reason tallies the tests produced.
+      V7  capacity        -> the info endpoint counts only handshaken peers;
+                             a fourth peer is refused at the configured limit,
+                             and a disconnected peer frees its slot.
 
 .EXAMPLE
     powershell -ExecutionPolicy Bypass -File tools\Test-NpcClaimValidation.ps1
@@ -124,6 +127,10 @@ function Get-RejectCounters {
     Invoke-RestMethod -Uri "http://localhost:$HttpPort/api/information/npc-validation" -TimeoutSec 5
 }
 
+function Get-ServerInfo {
+    Invoke-RestMethod -Uri "http://localhost:$HttpPort/api/information" -TimeoutSec 5
+}
+
 function Connect-Peer([string]$name) {
     $tcp = New-Object System.Net.Sockets.TcpClient('localhost', $TcpPort)
     $s = $tcp.GetStream(); $s.ReadTimeout = 8000
@@ -144,7 +151,7 @@ $serverExe = Join-Path $PSScriptRoot '..\dotnet\KcdMp.Server\bin\Debug\net8.0\Kc
 if (-not (Test-Path $serverExe)) { throw "relay not built: $serverExe (run dotnet build first)" }
 Write-Host "starting relay: $serverExe (tcp $TcpPort, http $HttpPort)"
 $env:ASPNETCORE_URLS = "http://localhost:$HttpPort"
-$relay = Start-Process -FilePath $serverExe -ArgumentList "--port", "$TcpPort" -PassThru -WindowStyle Hidden
+$relay = Start-Process -FilePath $serverExe -ArgumentList "--port", "$TcpPort", "--ServerInfo:MaxPlayers", "3" -PassThru -WindowStyle Hidden
 $deadline = (Get-Date).AddSeconds(15)
 $up = $false
 while (-not $up -and (Get-Date) -lt $deadline) {
@@ -156,11 +163,32 @@ if (-not $up) { throw "relay never opened tcp $TcpPort" }
 Start-Sleep -Milliseconds 500
 
 try {
+    $pendingProbe = New-Object System.Net.Sockets.TcpClient('localhost', $TcpPort)
+    Start-Sleep -Milliseconds 100
+    $info = Get-ServerInfo
+    Check "open connection without handshake is not counted as a player" ($info.players -eq 0) "got $($info.players)"
+    Check "info endpoint reports configured maxPlayers=3" ($info.maxPlayers -eq 3) "got $($info.maxPlayers)"
+
     $peerA = Connect-Peer 'wo66-auth-A'     # lowest id = world authority, passive receiver
     $peerB = Connect-Peer 'wo66-claim-B'
     $peerC = Connect-Peer 'wo66-claim-C'
     Write-Host "peers: A=id$($peerA.Id) B=id$($peerB.Id) C=id$($peerC.Id)"
     $null = Drain-NpcStates $peerA.Stream 800; $null = Drain-NpcStates $peerB.Stream 800; $null = Drain-NpcStates $peerC.Stream 800
+
+    $info = Get-ServerInfo
+    Check "info endpoint counts three handshaken peers" ($info.players -eq 3) "got $($info.players)"
+
+    $overflow = New-Object System.Net.Sockets.TcpClient('localhost', $TcpPort)
+    $overflowStream = $overflow.GetStream(); $overflowStream.ReadTimeout = 1500
+    $overflowName = [System.Text.Encoding]::UTF8.GetBytes('wo66-overflow-D')
+    $overflowHandshake = New-Object byte[] (2 + $overflowName.Length)
+    $overflowHandshake[0] = $PROTOCOL_VERSION; $overflowHandshake[1] = [byte]$overflowName.Length
+    [Array]::Copy($overflowName, 0, $overflowHandshake, 2, $overflowName.Length)
+    try { Send-Packet $overflowStream $HANDSHAKE $overflowHandshake } catch { }
+    $overflowReply = Read-Packet $overflowStream
+    Check "fourth connection refused at maxPlayers=3" ($null -eq $overflowReply) "unexpected packet type $($overflowReply.Type)"
+    $overflow.Close()
+    $pendingProbe.Close()
 
     Write-Host "`n--- V0: counters start at zero ---"
     $c0 = Get-RejectCounters
@@ -265,7 +293,18 @@ try {
     Check "reserved-name counter = 1" ($c1.reservedName -eq 1) "got $($c1.reservedName)"
     Check "stale-owner counter = 4"   ($c1.staleOwner -eq 4)   "got $($c1.staleOwner)"
 
-    $peerA.Tcp.Close(); $peerB.Tcp.Close(); $peerC.Tcp.Close()
+    $peerC.Tcp.Close()
+    $deadline = (Get-Date).AddSeconds(3)
+    do {
+        Start-Sleep -Milliseconds 100
+        $info = Get-ServerInfo
+    } while ($info.players -ne 2 -and (Get-Date) -lt $deadline)
+    Check "disconnect removes the peer from the info count" ($info.players -eq 2) "got $($info.players)"
+
+    $peerD = Connect-Peer 'wo66-replacement-D'
+    Check "replacement peer can use the freed slot" ($null -ne $peerD -and $peerD.Id -gt 0)
+
+    $peerA.Tcp.Close(); $peerB.Tcp.Close(); $peerD.Tcp.Close()
 }
 finally {
     if ($relay -and -not $relay.HasExited) { Stop-Process -Id $relay.Id -Force }


### PR DESCRIPTION
Track handshaken (ready) clients and enforce a configurable maxPlayers limit. Added a _readyClients HashSet and _maxPlayers from configuration, plus TryMarkReady to atomically reserve a slot during handshake. ClientSession now attempts to reserve a slot and rejects the handshake if the server is full; RemoveClient releases the slot. InformationController now reports ready client count. Extended Test-NpcClaimValidation.ps1 with capacity checks (start server with MaxPlayers=3, ensure unhandshaken sockets don't count, fourth handshake is refused, and freed slots are reusable).