### PR TITLE
Use 32-bit ghost IDs; bump protocol

### DIFF
--- a/KCDMP_launcher/Models/AppModels.cs
+++ b/KCDMP_launcher/Models/AppModels.cs
@@ -40,7 +40,7 @@ namespace KCDMP_launcher.Models
 
     public class PeerVersionData
     {
-        public byte GhostId { get; set; }
+        public uint GhostId { get; set; }
         public string ReleaseVersion { get; set; } = "";
     }
 

--- a/dotnet/KcdMp.Client/AsyncLogger.cs
+++ b/dotnet/KcdMp.Client/AsyncLogger.cs
@@ -1,0 +1,163 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Threading.Channels;
+
+namespace KcdMp.Client;
+
+/// <summary>
+/// Lazily starts one asynchronous output worker. Ordinary messages are queued;
+/// noisy event streams can be grouped by key and emitted as periodic summaries.
+/// </summary>
+internal sealed class AsyncLogger : IAsyncDisposable
+{
+    private sealed class Summary
+    {
+        public int Count;
+        public string Latest = "";
+        public double MetricTotal;
+        public int MetricCount;
+        public string? MetricName;
+        public string MetricUnit = "";
+    }
+
+    private readonly TimeSpan _summaryInterval;
+    private readonly Action<string> _output;
+    private readonly CancellationTokenSource _cts;
+    private readonly Channel<string> _messages = Channel.CreateBounded<string>(
+        new BoundedChannelOptions(1024)
+        {
+            SingleReader = true,
+            FullMode = BoundedChannelFullMode.DropOldest,
+        });
+    private readonly ConcurrentDictionary<string, Summary> _summaries = new();
+    private readonly object _workerGate = new();
+    private Task? _worker;
+
+    public AsyncLogger(CancellationToken sessionToken, TimeSpan? summaryInterval = null,
+        Action<string>? output = null)
+    {
+        _summaryInterval = summaryInterval ?? TimeSpan.FromSeconds(2);
+        _output = output ?? Console.WriteLine;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(sessionToken);
+    }
+
+    /// <summary>Queues a normal log line without blocking its caller on console I/O.</summary>
+    public void Log(string message)
+    {
+        EnsureWorker();
+        _messages.Writer.TryWrite(message);
+    }
+
+    /// <summary>
+    /// Adds one event to a keyed periodic summary. The latest detail is kept;
+    /// an optional numeric metric is averaged across the interval.
+    /// </summary>
+    public void Summarize(string key, string latest, double? metric = null,
+        string? metricName = null, string metricUnit = "")
+    {
+        Summary summary = _summaries.GetOrAdd(key, _ => new Summary());
+        lock (summary)
+        {
+            summary.Count++;
+            summary.Latest = latest;
+            if (metric.HasValue)
+            {
+                summary.MetricTotal += metric.Value;
+                summary.MetricCount++;
+                summary.MetricName = metricName;
+                summary.MetricUnit = metricUnit;
+            }
+        }
+        EnsureWorker();
+    }
+
+    private void EnsureWorker()
+    {
+        if (_worker is not null) return;
+        lock (_workerGate)
+            _worker ??= Task.Run(RunAsync);
+    }
+
+    private async Task RunAsync()
+    {
+        using var timer = new PeriodicTimer(_summaryInterval);
+        Task<bool> messageReady = _messages.Reader.WaitToReadAsync(_cts.Token).AsTask();
+        Task<bool> summaryReady = timer.WaitForNextTickAsync(_cts.Token).AsTask();
+
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                Task completed = await Task.WhenAny(messageReady, summaryReady);
+                if (completed == messageReady)
+                {
+                    if (!await messageReady) break;
+                    DrainMessages();
+                    messageReady = _messages.Reader.WaitToReadAsync(_cts.Token).AsTask();
+                }
+                if (completed == summaryReady)
+                {
+                    if (!await summaryReady) break;
+                    FlushSummaries();
+                    summaryReady = timer.WaitForNextTickAsync(_cts.Token).AsTask();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
+        finally
+        {
+            DrainMessages();
+            FlushSummaries();
+        }
+    }
+
+    private void DrainMessages()
+    {
+        while (_messages.Reader.TryRead(out string? message))
+            _output(message);
+    }
+
+    private void FlushSummaries()
+    {
+        foreach (var pair in _summaries)
+        {
+            int count;
+            string latest;
+            double metricTotal;
+            int metricCount;
+            string? metricName;
+            string metricUnit;
+            lock (pair.Value)
+            {
+                count = pair.Value.Count;
+                if (count == 0) continue;
+                latest = pair.Value.Latest;
+                metricTotal = pair.Value.MetricTotal;
+                metricCount = pair.Value.MetricCount;
+                metricName = pair.Value.MetricName;
+                metricUnit = pair.Value.MetricUnit;
+                pair.Value.Count = 0;
+                pair.Value.MetricTotal = 0;
+                pair.Value.MetricCount = 0;
+            }
+
+            string average = metricCount > 0 && metricName is not null
+                ? string.Create(CultureInfo.InvariantCulture,
+                    $", avg-{metricName}={metricTotal / metricCount:F1}{metricUnit}")
+                : "";
+            _output(string.Create(CultureInfo.InvariantCulture,
+                $"[{pair.Key}] {count} events/{_summaryInterval.TotalSeconds:F0}s, latest={latest}{average}"));
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _messages.Writer.TryComplete();
+        _cts.Cancel();
+        Task? worker;
+        lock (_workerGate) worker = _worker;
+        if (worker is not null)
+            await worker.ConfigureAwait(false);
+        _cts.Dispose();
+    }
+}

--- a/dotnet/KcdMp.Client/DiceIpcState.cs
+++ b/dotnet/KcdMp.Client/DiceIpcState.cs
@@ -56,14 +56,14 @@ public sealed class DiceIpcState
 {
     private readonly InteractionClient _interactions;
     private readonly DiceClient _dice;
-    private readonly Func<byte, string?> _lookupGhostName;
+    private readonly Func<uint, string?> _lookupGhostName;
 
     private readonly object _lock = new();
     private DiceInviteDto? _invite;
     private DiceSessionDto? _session;
     private ushort? _trackedSessionId;
 
-    public DiceIpcState(InteractionClient interactions, DiceClient dice, Func<byte, string?> lookupGhostName)
+    public DiceIpcState(InteractionClient interactions, DiceClient dice, Func<uint, string?> lookupGhostName)
     {
         _interactions = interactions;
         _dice = dice;

--- a/dotnet/KcdMp.Client/GameBridge.cs
+++ b/dotnet/KcdMp.Client/GameBridge.cs
@@ -63,7 +63,7 @@ public partial class GameBridge(ClientConfig config)
 
     // ghostId → display name, from Name packets. Lets an invite prompt say who
     // is asking instead of showing a bare relay id.
-    private readonly ConcurrentDictionary<byte, string> _ghostNames = new();
+    private readonly ConcurrentDictionary<uint, string> _ghostNames = new();
 
     // ghostId → CryEngine entity id, from the mod's spawn-time "ghostid"
     // event (WO-46). This is what the native swing path addresses a ghost by;
@@ -93,7 +93,7 @@ public partial class GameBridge(ClientConfig config)
 
     // WO-47: per-ghost swing counter -- rotates through the several real rows
     // a weapon class ships (slash/stab), so consecutive swings vary.
-    private readonly ConcurrentDictionary<byte, int> _ghostSwingIndex = new();
+    private readonly ConcurrentDictionary<uint, int> _ghostSwingIndex = new();
 
     // WO-49: npcName → local entity id of this world's copy of a puppeted
     // NPC, from the mod's puppet-start "npcid" event (same tostring-hex idiom
@@ -117,7 +117,7 @@ public partial class GameBridge(ClientConfig config)
     // for a peer whose Handshake carried none (an old build). Read by
     // VersionIpcServer so the launcher can compare it against this agent's
     // own ReleaseVersionInfo.Current without the wire protocol itself caring.
-    private readonly ConcurrentDictionary<byte, string> _ghostReleaseVersions = new();
+    private readonly ConcurrentDictionary<uint, string> _ghostReleaseVersions = new();
 
     // WO-50: one instance for the whole agent process, surviving reconnects —
     // see RunAsync. Null-safe throughout: Discord not running degrades to no
@@ -134,8 +134,8 @@ public partial class GameBridge(ClientConfig config)
     // applying a diff never needs an extra round trip to ask "what does this
     // ghost have on already".
     private HashSet<Guid>? _lastSentAppearance;
-    private readonly ConcurrentDictionary<byte, HashSet<Guid>> _ghostAppearance = new();
-    private readonly ConcurrentDictionary<byte, HashSet<Guid>> _ghostKnownItemClasses = new();
+    private readonly ConcurrentDictionary<uint, HashSet<Guid>> _ghostAppearance = new();
+    private readonly ConcurrentDictionary<uint, HashSet<Guid>> _ghostKnownItemClasses = new();
     // WO-58: item classes a ghost has proven it will never equip -- a full
     // verify-and-retry schedule ran and the final read still lacked them.
     // Without this, the failed class is dropped from `applied`, the next
@@ -154,7 +154,7 @@ public partial class GameBridge(ClientConfig config)
     // the one-way clothing reports. Ten minutes keeps ~95% of WO-58's
     // churn reduction (one 10 s retry cycle per item per 10 min instead of
     // one every 30 s) while letting legitimate changes heal.
-    private readonly ConcurrentDictionary<byte, Dictionary<Guid, DateTime>> _ghostNeverEquips = new();
+    private readonly ConcurrentDictionary<uint, Dictionary<Guid, DateTime>> _ghostNeverEquips = new();
 
     /// <summary>How long one exhausted verify schedule suppresses an item class for a ghost.</summary>
     private static readonly TimeSpan NeverEquipTtl = TimeSpan.FromMinutes(10);
@@ -189,7 +189,7 @@ public partial class GameBridge(ClientConfig config)
     // for its lifetime -- it does not change, and re-reading it on every
     // damage event would add a round trip to the hot path. Invalidated on
     // Disconnect alongside the other per-ghost caches.
-    private readonly ConcurrentDictionary<byte, Guid> _ghostSoulGuidCache = new();
+    private readonly ConcurrentDictionary<uint, Guid> _ghostSoulGuidCache = new();
 
     // How long a ghost stays attached to the hostile faction after the most
     // recent combat event involving it, before the sweep in the main tick
@@ -197,7 +197,7 @@ public partial class GameBridge(ClientConfig config)
     // so a sustained fight keeps it attached continuously rather than
     // flapping attach/detach every few seconds.
     private static readonly TimeSpan AggroHoldDuration = TimeSpan.FromSeconds(20);
-    private readonly ConcurrentDictionary<byte, DateTime> _ghostHostileUntilUtc = new();
+    private readonly ConcurrentDictionary<uint, DateTime> _ghostHostileUntilUtc = new();
 
     // The only channel to KCDMP_launcher's dice window -- see DiceIpcServer.
     private DiceIpcServer? _diceIpcServer;
@@ -253,7 +253,7 @@ public partial class GameBridge(ClientConfig config)
     // A peer's skip that resolved while our own was still resolving. Applied
     // once our own skip ends (SetWorldTime mid-skip is untested); only the
     // highest target is kept -- applying is forward-only anyway.
-    private (byte SourceId, byte Kind, uint WorldTime, bool Quiet)? _pendingTimeSkip;
+    private (uint SourceId, byte Kind, uint WorldTime, bool Quiet)? _pendingTimeSkip;
     private readonly object _timeSkipLock = new();
 
     // Clock-jump watcher: the fallback detector for time advances that emit
@@ -275,7 +275,7 @@ public partial class GameBridge(ClientConfig config)
     // apply PA's post-reload broadcast). Convergence is therefore forward and
     // ours: on a detected backward jump, this client fast-forwards ITSELF to
     // the best-known session clock. Solo reloads are left alone.
-    private readonly ConcurrentDictionary<byte, DateTime> _peerLastSeenUtc = new();
+    private readonly ConcurrentDictionary<uint, DateTime> _peerLastSeenUtc = new();
     private uint _peerWorldTime;               // last clock any peer reported (TimeSkipDown)
     private DateTime _peerWorldTimeUtc = DateTime.MinValue;
     /// <summary>Game-seconds per real second (WO-38 live: ratio 15, confirmed exactly).</summary>
@@ -336,7 +336,7 @@ public partial class GameBridge(ClientConfig config)
     // Relay-assigned ghost id of THIS client, from the connect Ack. The
     // receive loop needs it to tell the mod whether an ItemClaimDown echo
     // means "you won" (claimer == us) or "you lost, roll back".
-    private byte _myGhostId;
+    private uint _myGhostId;
 
     // ---- Shared player combat (WO-28) ----
 
@@ -397,7 +397,7 @@ public partial class GameBridge(ClientConfig config)
     // Same idiom for WO-28 Flow B: the mod reports a ghost health drop on the
     // log-tail event channel, which is read on the tail loop's own thread and
     // has no access to this connection's stream.
-    private Func<byte, float, float, Task>? _sendPlayerHit;
+    private Func<uint, float, float, Task>? _sendPlayerHit;
 
     // NPC sync (WO-32): set per connection like _sendPlayerHit; carries one
     // npc_state event line from the mod onto the wire as an NpcStateUp (0x26).
@@ -657,21 +657,23 @@ public partial class GameBridge(ClientConfig config)
         releaseVersionBytes.CopyTo(handshake, 5 + nameBytes.Length);
         await stream.WriteAsync(handshake);
 
-        // --- Ack (S→C 0xFF [id:1]) or rejection (S→C 0x09 [serverVersion:1]) ---
-        // Both are 4 bytes on the wire, so the type byte decides.
-        var reply = new byte[4]; // header(3) + 1
-        await ReadExactAsync(stream, reply);
+        // --- Ack (S→C 0xFF [id:4]) or rejection (S→C 0x09 [serverVersion:1]) ---
+        var replyHeader = new byte[3];
+        await ReadExactAsync(stream, replyHeader);
+        int replyPayloadLen = BinaryPrimitives.ReadUInt16LittleEndian(replyHeader.AsSpan(1));
+        var replyPayload = new byte[replyPayloadLen];
+        await ReadExactAsync(stream, replyPayload);
 
-        if (reply[0] == Protocol.VersionMismatch)
-            throw new ProtocolVersionMismatchException(reply[3]);
+        if (replyHeader[0] == Protocol.VersionMismatch && replyPayloadLen == 1)
+            throw new ProtocolVersionMismatchException(replyPayload[0]);
 
-        if (reply[0] != Protocol.Ack)
+        if (replyHeader[0] != Protocol.Ack || replyPayloadLen != Protocol.GhostIdLen)
         {
-            Console.WriteLine($"[!] Expected Ack, got packet type 0x{reply[0]:X2}. Dropping connection.");
+            Console.WriteLine($"[!] Expected Ack, got packet type 0x{replyHeader[0]:X2} with {replyPayloadLen} bytes. Dropping connection.");
             return;
         }
 
-        byte myId = reply[3];
+        uint myId = BinaryPrimitives.ReadUInt32LittleEndian(replyPayload);
         _myGhostId = myId;
         Console.WriteLine($"Connected! Assigned id={myId} (protocol v{Protocol.Version})");
         Console.WriteLine();
@@ -901,7 +903,8 @@ public partial class GameBridge(ClientConfig config)
             tailForPause.SkipTimeStateChanged += OnLocalSkipTime;
         }
 
-        var receiveTask     = ReceiveLoopAsync(stream, cts.Token);
+        var asyncLogger     = new AsyncLogger(cts.Token);
+        var receiveTask     = ReceiveLoopAsync(stream, asyncLogger, cts.Token);
         var pingTask        = PingLoopAsync(stream, cts.Token);
         var appearanceTask  = AppearanceLoopAsync(stream, cts.Token);
 
@@ -1069,7 +1072,10 @@ public partial class GameBridge(ClientConfig config)
                         _lastX = x; _lastY = y; _lastZ = z; _lastRotZ = rotZ;
                         await SendPositionAsync(stream, x, y, z, rotZ, riding);
                         if (moved)
-                            Console.WriteLine($"[pos] {x:F1} {y:F1} {z:F1}  rot={rotZ:F2}  riding={riding}  read={sw.ElapsedMilliseconds}ms");
+                            asyncLogger.Summarize("pos",
+                                string.Create(CultureInfo.InvariantCulture,
+                                    $"{x:F1} {y:F1} {z:F1}, rot={rotZ:F2}, riding={riding}"),
+                                sw.ElapsedMilliseconds, "read", "ms");
                     }
                 }
 
@@ -1090,6 +1096,7 @@ public partial class GameBridge(ClientConfig config)
         finally
         {
             cts.Cancel();
+            await asyncLogger.DisposeAsync();
             try { await receiveTask;     } catch { }
             try { await pingTask;        } catch { }
             try { await appearanceTask;  } catch { }
@@ -1360,7 +1367,7 @@ public partial class GameBridge(ClientConfig config)
     /// WO-47: the ghost's equipped Oversized-slot item class (halberd/polearm),
     /// or null when it has none / the catalog is unavailable.
     /// </summary>
-    private Guid? OversizedItemFor(byte ghostId)
+    private Guid? OversizedItemFor(uint ghostId)
     {
         var catalog = _swingCatalog.IsCompletedSuccessfully ? _swingCatalog.Result : null;
         if (catalog is null || !_ghostAppearance.TryGetValue(ghostId, out var applied))
@@ -1370,7 +1377,7 @@ public partial class GameBridge(ClientConfig config)
         return catalog.OversizedItemOf(snapshot);
     }
 
-    private string ResolveSwingSpec(byte ghostId)
+    private string ResolveSwingSpec(uint ghostId)
     {
         var catalog = _swingCatalog.IsCompletedSuccessfully ? _swingCatalog.Result : null;
         if (catalog is null || !_ghostAppearance.TryGetValue(ghostId, out var applied))
@@ -1474,7 +1481,7 @@ public partial class GameBridge(ClientConfig config)
     /// part of the diff -- unequips what dropped out, equips what is new.
     /// Never re-touches a slot that did not change.
     /// </summary>
-    private async Task ApplyAppearanceAsync(byte ghostId, Guid[] target, CancellationToken ct)
+    private async Task ApplyAppearanceAsync(uint ghostId, Guid[] target, CancellationToken ct)
     {
         // WO-40 Phase 10: substitute quest-item aliases with their real
         // source items before any diffing -- the alias class is what fails.
@@ -1565,7 +1572,7 @@ public partial class GameBridge(ClientConfig config)
     /// </summary>
     private static readonly int[] AppearanceRetryDelaysMs = [1000, 1000, 1000, 2000, 2000, 3000];
 
-    private async Task VerifyAndRetryAsync(string soulName, byte ghostId, List<Guid> toAdd,
+    private async Task VerifyAndRetryAsync(string soulName, uint ghostId, List<Guid> toAdd,
         HashSet<Guid> applied, CancellationToken ct)
     {
         var pending = new List<Guid>(toAdd);
@@ -2051,7 +2058,7 @@ public partial class GameBridge(ClientConfig config)
     /// when our own skip is still resolving -- SetWorldTime mid-skip is
     /// untested, and our own skip's result may supersede it anyway.
     /// </summary>
-    private async Task ApplyTimeSkipAsync(byte sourceId, byte kind, uint worldTime, bool quiet, CancellationToken ct)
+    private async Task ApplyTimeSkipAsync(uint sourceId, byte kind, uint worldTime, bool quiet, CancellationToken ct)
     {
         if (_localSkipActive || _awaitSkipDoneTime)
         {
@@ -2082,7 +2089,7 @@ public partial class GameBridge(ClientConfig config)
 
     private void ApplyPendingTimeSkipIfAny()
     {
-        (byte SourceId, byte Kind, uint WorldTime, bool Quiet)? pending;
+        (uint SourceId, byte Kind, uint WorldTime, bool Quiet)? pending;
         lock (_timeSkipLock)
         {
             pending = _pendingTimeSkip;
@@ -2167,7 +2174,7 @@ public partial class GameBridge(ClientConfig config)
         cts.Dispose();
     }
 
-    private async Task ApplyPeerPauseAsync(byte sourceGhostId, bool paused, CancellationToken ct)
+    private async Task ApplyPeerPauseAsync(uint sourceGhostId, bool paused, CancellationToken ct)
     {
         try
         {
@@ -2349,7 +2356,7 @@ public partial class GameBridge(ClientConfig config)
         catch (Exception ex) { Console.WriteLine($"[npcsync] send failed: {ex.Message}"); }
     }
 
-    private async Task SendPlayerHitAsync(NetworkStream stream, byte targetGhostId,
+    private async Task SendPlayerHitAsync(NetworkStream stream, uint targetGhostId,
                                           float healthLoss, float staminaLoss, CancellationToken ct)
     {
         if (!_isDamageAuthority)
@@ -2362,10 +2369,10 @@ public partial class GameBridge(ClientConfig config)
         var packet = new byte[3 + Protocol.PlayerHitUpPayloadLen];
         packet[0] = Protocol.PlayerHitUp;
         BinaryPrimitives.WriteUInt16LittleEndian(packet.AsSpan(1), Protocol.PlayerHitUpPayloadLen);
-        packet[3] = targetGhostId;
-        BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(4), healthLoss);
-        BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(8), staminaLoss);
-        packet[12] = 0;
+        BinaryPrimitives.WriteUInt32LittleEndian(packet.AsSpan(3), targetGhostId);
+        BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(3 + Protocol.GhostIdLen), healthLoss);
+        BinaryPrimitives.WriteSingleLittleEndian(packet.AsSpan(7 + Protocol.GhostIdLen), staminaLoss);
+        packet[11 + Protocol.GhostIdLen] = 0;
         try
         {
             await WritePacketAsync(stream, packet, ct);
@@ -2458,7 +2465,7 @@ public partial class GameBridge(ClientConfig config)
     // Receive loop – server pushes Ghost and Name packets to us
     // -------------------------------------------------------------------------
 
-    private async Task ReceiveLoopAsync(NetworkStream stream, CancellationToken ct)
+    private async Task ReceiveLoopAsync(NetworkStream stream, AsyncLogger asyncLogger, CancellationToken ct)
     {
         var header = new byte[3];
         try
@@ -2484,14 +2491,14 @@ public partial class GameBridge(ClientConfig config)
                 }
                 else if (type == Protocol.Ghost && payloadLen == Protocol.GhostPayloadLen)
                 {
-                    // Ghost: [ghostId:1][x:4f][y:4f][z:4f][rotZ:4f][flags:1]
+                    // Ghost: [ghostId:4][x:4f][y:4f][z:4f][rotZ:4f][flags:1]
                     // Length is exact now that the handshake pins the version.
-                    byte ghostId   = payload[0];
-                    float x        = ReadFloat(payload, 1);
-                    float y        = ReadFloat(payload, 5);
-                    float z        = ReadFloat(payload, 9);
-                    float rotZ     = ReadFloat(payload, 13);
-                    bool  isRiding = (payload[17] & 0x01) != 0;
+                    uint ghostId   = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    float x        = ReadFloat(payload, Protocol.GhostIdLen);
+                    float y        = ReadFloat(payload, Protocol.GhostIdLen + 4);
+                    float z        = ReadFloat(payload, Protocol.GhostIdLen + 8);
+                    float rotZ     = ReadFloat(payload, Protocol.GhostIdLen + 12);
+                    bool  isRiding = (payload[Protocol.GhostIdLen + 16] & 0x01) != 0;
                     // WO-59: a ghost id we have never seen this connection is
                     // a newly-arrived peer -- re-announce our clock so THEY
                     // converge too (our connect-time sync went out before
@@ -2504,27 +2511,30 @@ public partial class GameBridge(ClientConfig config)
                     RefreshDiscordPeerCount();
                     _voice?.UpdateGhostPos(ghostId, x, y, z);
                     await UpdateGhostAsync(ghostId.ToString(), x, y, z, rotZ, isRiding);
+                    asyncLogger.Summarize($"ghost {ghostId}",
+                        string.Create(CultureInfo.InvariantCulture,
+                            $"{x:F1} {y:F1} {z:F1}, rot={rotZ:F2}, riding={isRiding}"));
                 }
-                else if (type == Protocol.Name && payloadLen >= 2)
+                else if (type == Protocol.Name && payloadLen >= Protocol.GhostIdLen + 1)
                 {
-                    // Name packet: [ghostId:1][name:UTF-8...]
-                    byte ghostId = payload[0];
-                    string gname = Encoding.UTF8.GetString(payload, 1, payloadLen - 1);
+                    // Name packet: [ghostId:4][name:UTF-8...]
+                    uint ghostId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    string gname = Encoding.UTF8.GetString(payload, Protocol.GhostIdLen, payloadLen - Protocol.GhostIdLen);
                     _ghostNames[ghostId] = gname;
                     await SetGhostNameAsync(ghostId.ToString(), gname);
                 }
-                else if (type == Protocol.ReleaseVersion && payloadLen >= 2)
+                else if (type == Protocol.ReleaseVersion && payloadLen >= Protocol.GhostIdLen + 1)
                 {
-                    // ReleaseVersion (0x1E, WO-19): [ghostId:1][releaseVersion:UTF-8...]
-                    byte ghostId = payload[0];
-                    string releaseVersion = Encoding.UTF8.GetString(payload, 1, payloadLen - 1);
+                    // ReleaseVersion (0x1E, WO-19): [ghostId:4][releaseVersion:UTF-8...]
+                    uint ghostId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    string releaseVersion = Encoding.UTF8.GetString(payload, Protocol.GhostIdLen, payloadLen - Protocol.GhostIdLen);
                     _ghostReleaseVersions[ghostId] = releaseVersion;
                     Console.WriteLine($"[version] ghost {ghostId} is on release {releaseVersion}");
                 }
-                else if (type == Protocol.Disconnect && payloadLen == 1)
+                else if (type == Protocol.Disconnect && payloadLen == Protocol.GhostIdLen)
                 {
-                    // Disconnect packet: [ghostId:1]
-                    byte ghostId = payload[0];
+                    // Disconnect packet: [ghostId:4]
+                    uint ghostId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
                     Console.WriteLine($"[disconnect] ghost {ghostId} removed");
                     _peerLastSeenUtc.TryRemove(ghostId, out _);
                     RefreshDiscordPeerCount();
@@ -2541,23 +2551,23 @@ public partial class GameBridge(ClientConfig config)
                     await ApplyPeerPauseAsync(ghostId, paused: false, ct);
                     try { await ExecLuaAsync($"KCD2MP_RemoveGhost(\"{ghostId}\")"); } catch { }
                 }
-                else if (type == Protocol.VoiceDown && payloadLen == 1 + Protocol.VoiceFrameLen)
+                else if (type == Protocol.VoiceDown && payloadLen == Protocol.GhostIdLen + Protocol.VoiceFrameLen)
                 {
-                    // Voice packet: [sourceId:1][pcm: 640 bytes]
-                    byte sourceId = payload[0];
+                    // Voice packet: [sourceId:4][pcm: 640 bytes]
+                    uint sourceId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
                     var pcm = new byte[Protocol.VoiceFrameLen];
-                    Buffer.BlockCopy(payload, 1, pcm, 0, Protocol.VoiceFrameLen);
+                    Buffer.BlockCopy(payload, Protocol.GhostIdLen, pcm, 0, Protocol.VoiceFrameLen);
                     _voice?.OnVoiceReceived(sourceId, pcm);
                 }
                 else if (type == Protocol.DamageDown && payloadLen == Protocol.DamageDownPayloadLen)
                 {
-                    // Damage: [sourceGhostId:1][guid:16][stamina:4f][health:4f][flags:1]
+                    // Damage: [sourceGhostId:4][guid:16][stamina:4f][health:4f][flags:1]
                     // Applied through the DLL, not Lua: Lua writes are inert.
-                    byte  sourceId = payload[0];
-                    var   soul     = new Guid(payload.AsSpan(1, 16));
-                    float stamina  = ReadFloat(payload, 17);
-                    float health   = ReadFloat(payload, 21);
-                    bool  suppress = (payload[25] & Protocol.DamageFlagSuppressHitReaction) != 0;
+                    uint  sourceId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    var   soul     = new Guid(payload.AsSpan(Protocol.GhostIdLen, 16));
+                    float stamina  = ReadFloat(payload, Protocol.GhostIdLen + 16);
+                    float health   = ReadFloat(payload, Protocol.GhostIdLen + 20);
+                    bool  suppress = (payload[Protocol.GhostIdLen + 24] & Protocol.DamageFlagSuppressHitReaction) != 0;
 
                     bool applied = await _combat.ApplyDamageAsync(soul, stamina, health, suppress, ct);
                     if (!applied)
@@ -2570,23 +2580,24 @@ public partial class GameBridge(ClientConfig config)
                         _ = TriggerReactiveAggroAsync(sourceId, ct);
                 }
                 else if (type == Protocol.NpcDamageDown
-                         && payloadLen >= 1 + 1 + 1 + Protocol.NpcDamageFixedTail
-                         && payloadLen <= 1 + 1 + Protocol.MaxNpcNameLen + Protocol.NpcDamageFixedTail)
+                         && payloadLen >= Protocol.GhostIdLen + 1 + 1 + Protocol.NpcDamageFixedTail
+                         && payloadLen <= Protocol.GhostIdLen + 1 + Protocol.MaxNpcNameLen + Protocol.NpcDamageFixedTail)
                 {
                     // Name-addressed NPC damage (WO-40 Phase 5):
-                    // [sourceGhostId:1][nameLen:1][name][stamina:4f][health:4f][flags:1].
+                    // [sourceGhostId:4][nameLen:1][name][stamina:4f][health:4f][flags:1].
                     // The name resolves to THIS install's per-save guid via the
                     // reflection REST (cached), then applies through the same
                     // DLL pipe as 0x22 -- so the DLL's credit-out still stops
                     // echoes.
-                    byte ndSource = payload[0];
-                    int ndNameLen = payload[1];
-                    if (payloadLen == 2 + ndNameLen + Protocol.NpcDamageFixedTail)
+                    uint ndSource = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    int ndNameLen = payload[Protocol.GhostIdLen];
+                    if (payloadLen == Protocol.GhostIdLen + 1 + ndNameLen + Protocol.NpcDamageFixedTail)
                     {
-                        string ndName = Encoding.UTF8.GetString(payload, 2, ndNameLen);
+                        int ndNameOffset = Protocol.GhostIdLen + 1;
+                        string ndName = Encoding.UTF8.GetString(payload, ndNameOffset, ndNameLen);
                         if (NpcNamePattern.IsMatch(ndName))
                         {
-                            int no = 2 + ndNameLen;
+                            int no = ndNameOffset + ndNameLen;
                             float ndStamina = ReadFloat(payload, no);
                             float ndHealth  = ReadFloat(payload, no + 4);
                             bool  ndSupp    = (payload[no + 8] & Protocol.DamageFlagSuppressHitReaction) != 0;
@@ -2605,8 +2616,8 @@ public partial class GameBridge(ClientConfig config)
                 {
                     // Death is its own packet rather than inferred from health
                     // reaching zero, and the DLL treats it as idempotent.
-                    byte sourceId = payload[0];
-                    var  soul     = new Guid(payload.AsSpan(1, 16));
+                    uint sourceId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    var  soul     = new Guid(payload.AsSpan(Protocol.GhostIdLen, 16));
                     bool applied  = await _combat.ApplyDeathAsync(soul, ct);
                     if (!applied)
                         Console.WriteLine($"[combat] death from ghost {sourceId} not applied " +
@@ -2614,21 +2625,21 @@ public partial class GameBridge(ClientConfig config)
                 }
                 else if (type == Protocol.PauseDown && payloadLen == Protocol.PauseDownPayloadLen)
                 {
-                    // PauseDown: [sourceGhostId:1][state:1]
-                    byte sourceId = payload[0];
-                    bool paused = payload[1] == Protocol.PauseStateEntered;
+                    // PauseDown: [sourceGhostId:4][state:1]
+                    uint sourceId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    bool paused = payload[Protocol.GhostIdLen] == Protocol.PauseStateEntered;
                     await ApplyPeerPauseAsync(sourceId, paused, ct);
                 }
                 else if (type == Protocol.PlayerStateDown && payloadLen == Protocol.PlayerStateDownPayloadLen)
                 {
-                    // WO-28 Flow A: [ghostId:1][health:4f][stamina:4f][flags:1]
+                    // WO-28 Flow A: [ghostId:4][health:4f][stamina:4f][flags:1]
                     // Rendered, not reconciled -- a player's health is
                     // authoritative on their own machine, so this is simply
                     // what that ghost's health IS.
-                    byte  sourceId = payload[0];
-                    float health   = ReadFloat(payload, 1);
-                    float stamina  = ReadFloat(payload, 5);
-                    byte  vflags   = payload[9];
+                    uint  sourceId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    float health   = ReadFloat(payload, Protocol.GhostIdLen);
+                    float stamina  = ReadFloat(payload, Protocol.GhostIdLen + 4);
+                    byte  vflags   = payload[Protocol.GhostIdLen + 8];
                     await ApplyGhostVitalsAsync(sourceId, health, stamina, vflags, ct);
                 }
                 else if (type == Protocol.PlayerHitDown && payloadLen == Protocol.PlayerHitDownPayloadLen)
@@ -2642,9 +2653,9 @@ public partial class GameBridge(ClientConfig config)
                 }
                 else if (type == Protocol.PlayerDeathDown && payloadLen == Protocol.PlayerDeathDownPayloadLen)
                 {
-                    // WO-28 Flow C: [ghostId:1]. Idempotent -- the mod's own
+                    // WO-28 Flow C: [ghostId:4]. Idempotent -- the mod's own
                     // setter only logs on an actual transition.
-                    byte sourceId = payload[0];
+                    uint sourceId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
                     string who = _ghostNames.TryGetValue(sourceId, out var dn) ? dn : $"player {sourceId}";
                     Console.WriteLine($"[death] {who} died and is reloading their own save");
                     try
@@ -2660,14 +2671,14 @@ public partial class GameBridge(ClientConfig config)
                 }
                 else if (type == Protocol.TimeSkipDown && payloadLen == Protocol.TimeSkipDownPayloadLen)
                 {
-                    // Time-skip sync (WO-38): [sourceGhostId:1][phase:1][kind:1][worldTime:4].
+                    // Time-skip sync (WO-38): [sourceGhostId:4][phase:1][kind:1][worldTime:4].
                     // A start carries no time and needs nothing done here --
                     // the join rule is enforced relay-side. Both done phases
                     // apply the clock; only the announced one shows a toast.
-                    byte  tsSource = payload[0];
-                    byte  tsPhase  = payload[1];
-                    byte  tsKind   = payload[2];
-                    uint  tsTime   = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(3));
+                    uint  tsSource = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    byte  tsPhase  = payload[Protocol.GhostIdLen];
+                    byte  tsKind   = payload[Protocol.GhostIdLen + 1];
+                    uint  tsTime   = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(Protocol.GhostIdLen + 2));
                     if (tsPhase == Protocol.TimeSkipPhaseStart)
                     {
                         string tsWho = _ghostNames.TryGetValue(tsSource, out var tsName) ? tsName : $"player {tsSource}";
@@ -2686,21 +2697,22 @@ public partial class GameBridge(ClientConfig config)
                     }
                 }
                 else if (type == Protocol.NpcStateDown
-                         && payloadLen >= 1 + 1 + 1 + Protocol.NpcStateFixedTail
-                         && payloadLen <= 1 + 1 + Protocol.MaxNpcNameLen + Protocol.NpcStateFixedTail)
+                         && payloadLen >= Protocol.GhostIdLen + 1 + 1 + Protocol.NpcStateFixedTail
+                         && payloadLen <= Protocol.GhostIdLen + 1 + Protocol.MaxNpcNameLen + Protocol.NpcStateFixedTail)
                 {
-                    // NPC sync (WO-32): [sourceGhostId:1][nameLen:1][name][x][y][z][rotZ][health][flags]
+                    // NPC sync (WO-32): [sourceGhostId:4][nameLen:1][name][x][y][z][rotZ][health][flags]
                     // The name is validated before interpolation -- it crosses
                     // into a Lua string literal and relay data must not be able
                     // to inject code. A name for an entity not loaded in this
                     // world is handled (ignored) on the Lua side.
-                    int nameLen = payload[1];
-                    if (payloadLen == 2 + nameLen + Protocol.NpcStateFixedTail)
+                    int nameLen = payload[Protocol.GhostIdLen];
+                    if (payloadLen == Protocol.GhostIdLen + 1 + nameLen + Protocol.NpcStateFixedTail)
                     {
-                        string npcName = Encoding.UTF8.GetString(payload, 2, nameLen);
+                        int npcNameOffset = Protocol.GhostIdLen + 1;
+                        string npcName = Encoding.UTF8.GetString(payload, npcNameOffset, nameLen);
                         if (NpcNamePattern.IsMatch(npcName))
                         {
-                            int o = 2 + nameLen;
+                            int o = npcNameOffset + nameLen;
                             float nx    = ReadFloat(payload, o);
                             float ny    = ReadFloat(payload, o + 4);
                             float nz    = ReadFloat(payload, o + 8);
@@ -2752,33 +2764,34 @@ public partial class GameBridge(ClientConfig config)
                     }
                 }
                 else if (type == Protocol.HorseInfoDown
-                         && payloadLen >= 2
-                         && payloadLen <= 2 + Protocol.MaxHorseNameLen)
+                         && payloadLen >= Protocol.GhostIdLen + 1
+                         && payloadLen <= Protocol.GhostIdLen + 1 + Protocol.MaxHorseNameLen)
                 {
-                    // Horse identity (WO-38 Phase 5): [sourceGhostId:1][nameLen:1][name].
+                    // Horse identity (WO-38 Phase 5): [sourceGhostId:4][nameLen:1][name].
                     // Same validate-before-Lua-interpolation discipline as NpcStateDown.
-                    byte hiSource = payload[0];
-                    int hiNameLen = payload[1];
-                    if (payloadLen == 2 + hiNameLen)
+                    uint hiSource = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    int hiNameLen = payload[Protocol.GhostIdLen];
+                    if (payloadLen == Protocol.GhostIdLen + 1 + hiNameLen)
                     {
-                        string horseName = hiNameLen == 0 ? "" : Encoding.UTF8.GetString(payload, 2, hiNameLen);
+                        string horseName = hiNameLen == 0 ? "" : Encoding.UTF8.GetString(payload, Protocol.GhostIdLen + 1, hiNameLen);
                         if (hiNameLen == 0 || NpcNamePattern.IsMatch(horseName))
                             await ExecLuaAsync($"if KCD2MP_SetGhostHorse then KCD2MP_SetGhostHorse(\"{hiSource}\",\"{horseName}\") end");
                     }
                 }
                 else if (type == Protocol.WeatherDown
-                         && payloadLen >= 1 + 1 + 2
-                         && payloadLen <= 1 + 1 + Protocol.MaxWeatherNameLen + 2)
+                         && payloadLen >= Protocol.GhostIdLen + 1 + 2
+                         && payloadLen <= Protocol.GhostIdLen + 1 + Protocol.MaxWeatherNameLen + 2)
                 {
                     // Weather sync (WO-40 Phase 3):
-                    // [sourceGhostId:1][nameLen:1][profileName][blendSec:2].
+                    // [sourceGhostId:4][nameLen:1][profileName][blendSec:2].
                     // Same validate-before-Lua-interpolation discipline as
                     // NpcStateDown; the apply is change-gated.
-                    int wNameLen = payload[1];
-                    if (config.WeatherSyncEnabled && payloadLen == 2 + wNameLen + 2)
+                    int wNameLen = payload[Protocol.GhostIdLen];
+                    int wNameOffset = Protocol.GhostIdLen + 1;
+                    if (config.WeatherSyncEnabled && payloadLen == wNameOffset + wNameLen + 2)
                     {
-                        string wProfile = Encoding.UTF8.GetString(payload, 2, wNameLen);
-                        ushort wBlend = BinaryPrimitives.ReadUInt16LittleEndian(payload.AsSpan(2 + wNameLen));
+                        string wProfile = Encoding.UTF8.GetString(payload, wNameOffset, wNameLen);
+                        ushort wBlend = BinaryPrimitives.ReadUInt16LittleEndian(payload.AsSpan(wNameOffset + wNameLen));
                         if (WeatherNamePattern.IsMatch(wProfile))
                             await ApplyWeatherAsync(wProfile, wBlend);
                     }
@@ -2786,20 +2799,20 @@ public partial class GameBridge(ClientConfig config)
                 else if (type == Protocol.ItemDropDown && payloadLen == Protocol.ItemDropDownPayloadLen)
                 {
                     // Dropped-item sync (WO-48):
-                    // [sourceGhostId:1][dropId:4][itemClass:16][amount:2][health:4f][x:4f][y:4f][z:4f].
+                    // [sourceGhostId:4][dropId:4][itemClass:16][amount:2][health:4f][x:4f][y:4f][z:4f].
                     // Handed to the mod as a pending drop; it materializes the
                     // pickup entity only once the local player is near enough
                     // for the ground to be streamed (placing far away was
                     // observed to drop the item through the world). Dedupe by
                     // dropId is the mod's job -- heartbeats repeat this packet.
-                    byte idSource   = payload[0];
-                    uint idDropId   = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(1));
-                    var  idClass    = new Guid(payload.AsSpan(5, Protocol.ItemClassLen));
-                    ushort idAmount = BinaryPrimitives.ReadUInt16LittleEndian(payload.AsSpan(21));
-                    float idHealth  = ReadFloat(payload, 23);
-                    float idX       = ReadFloat(payload, 27);
-                    float idY       = ReadFloat(payload, 31);
-                    float idZ       = ReadFloat(payload, 35);
+                    uint idSource   = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    uint idDropId   = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(Protocol.GhostIdLen));
+                    var  idClass    = new Guid(payload.AsSpan(Protocol.GhostIdLen + 4, Protocol.ItemClassLen));
+                    ushort idAmount = BinaryPrimitives.ReadUInt16LittleEndian(payload.AsSpan(Protocol.GhostIdLen + 20));
+                    float idHealth  = ReadFloat(payload, Protocol.GhostIdLen + 22);
+                    float idX       = ReadFloat(payload, Protocol.GhostIdLen + 26);
+                    float idY       = ReadFloat(payload, Protocol.GhostIdLen + 30);
+                    float idZ       = ReadFloat(payload, Protocol.GhostIdLen + 34);
                     if (idDropId != 0 && idAmount > 0)
                         await ExecLuaAsync(string.Format(CultureInfo.InvariantCulture,
                             "if KCD2MP_ItemDropAdd then KCD2MP_ItemDropAdd(\"{0}\",\"{1}\",{2},{3:F4},{4:F3},{5:F3},{6:F3},\"{7}\") end",
@@ -2807,13 +2820,13 @@ public partial class GameBridge(ClientConfig config)
                 }
                 else if (type == Protocol.ItemClaimDown && payloadLen == Protocol.ItemClaimDownPayloadLen)
                 {
-                    // [claimerGhostId:1][dropId:4]. The relay echoes claims to
+                    // [claimerGhostId:4][dropId:4]. The relay echoes claims to
                     // everyone INCLUDING the claimant, in arrival order -- the
                     // first echo a client sees for a dropId settles that drop
                     // everywhere (the mod ignores repeats). Also retires the
                     // drop from our own heartbeat set, whoever won it.
-                    byte icClaimer = payload[0];
-                    uint icDropId  = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(1));
+                    uint icClaimer = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    uint icDropId  = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(Protocol.GhostIdLen));
                     _myOpenDrops.TryRemove(icDropId, out _);
                     bool claimIsMine = icClaimer == _myGhostId;
                     Console.WriteLine($"[itemsync] drop {icDropId} claimed by {(claimIsMine ? "us" : $"ghost {icClaimer}")}");
@@ -2821,14 +2834,14 @@ public partial class GameBridge(ClientConfig config)
                 }
                 else if (type == Protocol.CombatEventDown && payloadLen == Protocol.CombatEventDownPayloadLen)
                 {
-                    // Combat visibility (WO-39 Phase 1): [sourceGhostId:1][event:1].
+                    // Combat visibility (WO-39 Phase 1): [sourceGhostId:4][event:1].
                     // Purely cosmetic on this side -- the Lua applies a
                     // draw/holster call or a one-shot animation to the ghost.
                     // An event byte this build does not know is passed through
                     // anyway; the Lua ignores unknown values, so a newer peer
                     // can emit new events without breaking us.
-                    byte ceSource = payload[0];
-                    byte ceEvent  = payload[1];
+                    uint ceSource = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    byte ceEvent  = payload[Protocol.GhostIdLen];
                     // WO-46: swings go native when the ghost's entity id is
                     // known and the DLL pipe is up — the WO-45 rung-2 route
                     // renders a real, complete Mannequin swing where the Lua
@@ -2871,16 +2884,17 @@ public partial class GameBridge(ClientConfig config)
                         await ExecLuaAsync($"if KCD2MP_GhostCombat then KCD2MP_GhostCombat(\"{ceSource}\",{ceEvent}) end");
                     }
                 }
-                else if (type == Protocol.AppearanceDown && payloadLen >= 2)
+                else if (type == Protocol.AppearanceDown && payloadLen >= Protocol.GhostIdLen + 1)
                 {
-                    // Appearance: [sourceGhostId:1][itemCount:1][itemClass:16]*itemCount
-                    byte sourceId = payload[0];
-                    int itemCount = payload[1];
-                    if (payloadLen == 2 + itemCount * Protocol.ItemClassLen)
+                    // Appearance: [sourceGhostId:4][itemCount:1][itemClass:16]*itemCount
+                    uint sourceId = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                    int itemCount = payload[Protocol.GhostIdLen];
+                    int itemsOffset = Protocol.GhostIdLen + 1;
+                    if (payloadLen == itemsOffset + itemCount * Protocol.ItemClassLen)
                     {
                         var items = new Guid[itemCount];
                         for (int i = 0; i < itemCount; i++)
-                            items[i] = new Guid(payload.AsSpan(2 + i * Protocol.ItemClassLen, Protocol.ItemClassLen));
+                            items[i] = new Guid(payload.AsSpan(itemsOffset + i * Protocol.ItemClassLen, Protocol.ItemClassLen));
                         _ = ApplyAppearanceAsync(sourceId, items, ct);
                     }
                 }
@@ -2913,7 +2927,6 @@ public partial class GameBridge(ClientConfig config)
         try
         {
             await ExecLuaAsync($@"KCD2MP_UpdateGhost(""{ghostId}"",{gx},{gy},{gz},{rot},{ride})");
-            Console.WriteLine($"[ghost {ghostId}] {gx} {gy} {gz} riding={isRiding}");
         }
         catch { /* game might have unloaded */ }
     }
@@ -2924,7 +2937,7 @@ public partial class GameBridge(ClientConfig config)
     /// alive -- a completed save reload is exactly "their vitals started
     /// arriving again", so nothing else has to detect the end of a death.
     /// </summary>
-    private async Task ApplyGhostVitalsAsync(byte ghostId, float health, float stamina, byte flags, CancellationToken ct)
+    private async Task ApplyGhostVitalsAsync(uint ghostId, float health, float stamina, byte flags, CancellationToken ct)
     {
         string h = health.ToString("F1", CultureInfo.InvariantCulture);
         string s = stamina.ToString("F1", CultureInfo.InvariantCulture);
@@ -3099,7 +3112,7 @@ public partial class GameBridge(ClientConfig config)
                 // would drain a real player's stamina on a guess.
                 var bits = arg.Split(' ', StringSplitOptions.RemoveEmptyEntries);
                 if (bits.Length < 2
-                    || !byte.TryParse(bits[0], out byte hitGhostId)
+                    || !uint.TryParse(bits[0], out uint hitGhostId)
                     || !float.TryParse(bits[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float loss))
                 {
                     Console.WriteLine($"[playerhit] malformed ghost_hit '{arg}'");
@@ -3283,7 +3296,7 @@ public partial class GameBridge(ClientConfig config)
                 // KCD2MP.dice.wagerAmount; Lua already checked its own balance
                 // before emitting this, so no re-check happens here.
                 var parts = arg.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length < 1 || !byte.TryParse(parts[0], out byte targetId))
+                if (parts.Length < 1 || !uint.TryParse(parts[0], out uint targetId))
                 {
                     Console.WriteLine($"[interaction] malformed invite_send '{arg}'");
                     break;
@@ -3372,7 +3385,7 @@ public partial class GameBridge(ClientConfig config)
     /// nothing) while the ghost is not yet a real soul the game will answer
     /// for -- a normal, transient state right after spawn.
     /// </summary>
-    private async Task<Guid?> ResolveGhostSoulGuidAsync(byte ghostId, CancellationToken ct)
+    private async Task<Guid?> ResolveGhostSoulGuidAsync(uint ghostId, CancellationToken ct)
     {
         if (_ghostSoulGuidCache.TryGetValue(ghostId, out var cached)) return cached;
 
@@ -3388,7 +3401,7 @@ public partial class GameBridge(ClientConfig config)
     /// No-op, silently, when aggro is disabled: every caller of this can stay
     /// unconditional, keeping the toggle-off path simple to audit.
     /// </summary>
-    private async Task TriggerReactiveAggroAsync(byte ghostId, CancellationToken ct)
+    private async Task TriggerReactiveAggroAsync(uint ghostId, CancellationToken ct)
     {
         if (!_aggroEnabled) return;
 
@@ -3416,7 +3429,7 @@ public partial class GameBridge(ClientConfig config)
     /// (WO-39/WO-40 -- per-save Guids are field-confirmed unstable), and this
     /// runs once per spawn or per toggle, not on any hot path.
     ///
-    /// Ghost ids are strings here, not the byte ids <see cref="_ghostSoulGuidCache"/>
+    /// Ghost ids are strings here, not the numeric ids <see cref="_ghostSoulGuidCache"/>
     /// uses, so the locally-spawned test ghost ("test_ghost") is covered too.
     ///
     /// Never throws into its caller: every failure is a log line. A ghost that
@@ -3448,7 +3461,7 @@ public partial class GameBridge(ClientConfig config)
     }
 
     /// <summary>Detaches one ghost back to its pre-attach orphan state.</summary>
-    private async Task DetachGhostAggroAsync(byte ghostId, CancellationToken ct)
+    private async Task DetachGhostAggroAsync(uint ghostId, CancellationToken ct)
     {
         _ghostHostileUntilUtc.TryRemove(ghostId, out _);
         if (!_ghostSoulGuidCache.TryGetValue(ghostId, out var guid)) return;

--- a/dotnet/KcdMp.Client/InteractionClient.cs
+++ b/dotnet/KcdMp.Client/InteractionClient.cs
@@ -7,10 +7,10 @@ namespace KcdMp.Client;
 /// from the Invite's opaque config, forwarded on InviteReceived -- 0 for no
 /// stake, or for any kind that does not use one.
 /// </summary>
-public sealed record PendingInvite(ushort SessionId, byte FromGhostId, InteractionKind Kind, DateTime ReceivedUtc, int WagerAmount = 0);
+public sealed record PendingInvite(ushort SessionId, uint FromGhostId, InteractionKind Kind, DateTime ReceivedUtc, int WagerAmount = 0);
 
 /// <summary>A session both players agreed to.</summary>
-public sealed record ActiveSession(ushort SessionId, byte PeerGhostId, InteractionKind Kind, SessionRole Role);
+public sealed record ActiveSession(ushort SessionId, uint PeerGhostId, InteractionKind Kind, SessionRole Role);
 
 /// <summary>
 /// Agent-side half of the interaction layer (WO-2).
@@ -51,7 +51,7 @@ public sealed class InteractionClient(Func<byte, byte[], CancellationToken, Task
     /// An opaque event arrived from the peer. Interpreting the payload is the
     /// interaction's job, not this layer's.
     /// </summary>
-    public event Action<ushort, byte, byte[]>? SessionEvent;
+    public event Action<ushort, uint, byte[]>? SessionEvent;
 
     /// <summary>A session or pending invite ended, for the given reason.</summary>
     public event Action<ushort, SessionEndReason>? SessionEnded;
@@ -66,14 +66,14 @@ public sealed class InteractionClient(Func<byte, byte[], CancellationToken, Task
     /// score, WO-33's dice wager) -- opaque to this layer, same as
     /// SessionEvent's payload.
     /// </summary>
-    public Task InviteAsync(byte targetGhostId, InteractionKind kind, byte[]? config = null, CancellationToken ct = default)
+    public Task InviteAsync(uint targetGhostId, InteractionKind kind, byte[]? config = null, CancellationToken ct = default)
     {
         config ??= [];
-        var payload = new byte[3 + config.Length];
-        payload[0] = targetGhostId;
-        payload[1] = (byte)kind;
-        payload[2] = (byte)config.Length;
-        config.CopyTo(payload, 3);
+        var payload = new byte[Protocol.GhostIdLen + 2 + config.Length];
+        BinaryPrimitives.WriteUInt32LittleEndian(payload, targetGhostId);
+        payload[Protocol.GhostIdLen] = (byte)kind;
+        payload[Protocol.GhostIdLen + 1] = (byte)config.Length;
+        config.CopyTo(payload, Protocol.GhostIdLen + 2);
         return sendPacket(Protocol.Invite, payload, ct);
     }
 
@@ -140,23 +140,24 @@ public sealed class InteractionClient(Func<byte, byte[], CancellationToken, Task
     {
         switch (type)
         {
-            case Protocol.InviteReceived when payload.Length >= 4:
+            case Protocol.InviteReceived when payload.Length >= 2 + Protocol.GhostIdLen + 1:
             {
                 // config trailer added WO-33: [configLen:1][config:configLen],
-                // same shape Invite itself sends. A pre-WO-33 relay never
-                // appends it, so payload.Length == 4 there and wager stays 0.
+                // same shape Invite itself sends. When absent, wager stays 0.
                 int wager = 0;
-                if (payload.Length >= 5)
+                int configLenOffset = 2 + Protocol.GhostIdLen + 1;
+                int configOffset = configLenOffset + 1;
+                if (payload.Length > configLenOffset)
                 {
-                    int configLen = payload[4];
-                    if (payload.Length >= 5 + configLen && configLen >= 10)
-                        wager = BinaryPrimitives.ReadInt32LittleEndian(payload.AsSpan(5 + 6, 4));
+                    int configLen = payload[configLenOffset];
+                    if (payload.Length >= configOffset + configLen && configLen >= 10)
+                        wager = BinaryPrimitives.ReadInt32LittleEndian(payload.AsSpan(configOffset + 6, 4));
                 }
 
                 var invite = new PendingInvite(
                     BinaryPrimitives.ReadUInt16LittleEndian(payload),
-                    payload[2],
-                    (InteractionKind)payload[3],
+                    BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(2)),
+                    (InteractionKind)payload[2 + Protocol.GhostIdLen],
                     DateTime.UtcNow,
                     wager);
 
@@ -165,13 +166,13 @@ public sealed class InteractionClient(Func<byte, byte[], CancellationToken, Task
                 return true;
             }
 
-            case Protocol.SessionStart when payload.Length >= 5:
+            case Protocol.SessionStart when payload.Length >= 2 + Protocol.GhostIdLen + 2:
             {
                 var session = new ActiveSession(
                     BinaryPrimitives.ReadUInt16LittleEndian(payload),
-                    payload[2],
-                    (InteractionKind)payload[3],
-                    (SessionRole)payload[4]);
+                    BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(2)),
+                    (InteractionKind)payload[2 + Protocol.GhostIdLen],
+                    (SessionRole)payload[3 + Protocol.GhostIdLen]);
 
                 lock (_lock)
                 {
@@ -182,10 +183,10 @@ public sealed class InteractionClient(Func<byte, byte[], CancellationToken, Task
                 return true;
             }
 
-            case Protocol.SessionEventDown when payload.Length >= 3:
+            case Protocol.SessionEventDown when payload.Length >= 2 + Protocol.GhostIdLen:
             {
                 ushort sid = BinaryPrimitives.ReadUInt16LittleEndian(payload);
-                byte from = payload[2];
+                uint from = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(2));
 
                 // Ignore events for a session we are not in: the relay should
                 // never send one, and acting on it would be worse than dropping.
@@ -194,7 +195,7 @@ public sealed class InteractionClient(Func<byte, byte[], CancellationToken, Task
                     if (_active is null || _active.SessionId != sid) return true;
                 }
 
-                SessionEvent?.Invoke(sid, from, payload[3..]);
+                SessionEvent?.Invoke(sid, from, payload[(2 + Protocol.GhostIdLen)..]);
                 return true;
             }
 

--- a/dotnet/KcdMp.Client/VersionIpcServer.cs
+++ b/dotnet/KcdMp.Client/VersionIpcServer.cs
@@ -19,7 +19,7 @@ namespace KcdMp.Client;
 ///
 /// GET /version-status -> { "myReleaseVersion": "0.9.5", "peers": [{"ghostId":1,"releaseVersion":"0.9.4"}] }
 /// </summary>
-public sealed class VersionIpcServer(Func<KeyValuePair<byte, string>[]> getPeers, int port)
+public sealed class VersionIpcServer(Func<KeyValuePair<uint, string>[]> getPeers, int port)
 {
     private readonly HttpListener _listener = new();
     private CancellationTokenSource? _cts;
@@ -138,4 +138,4 @@ public sealed class VersionIpcServer(Func<KeyValuePair<byte, string>[]> getPeers
 }
 
 public sealed record VersionStatusDto(string MyReleaseVersion, PeerVersionDto[] Peers);
-public sealed record PeerVersionDto(byte GhostId, string ReleaseVersion);
+public sealed record PeerVersionDto(uint GhostId, string ReleaseVersion);

--- a/dotnet/KcdMp.Client/VoiceChat.cs
+++ b/dotnet/KcdMp.Client/VoiceChat.cs
@@ -32,12 +32,12 @@ public sealed class VoiceChat : IDisposable
     private WaveOutEvent?          _waveOut;
     private MixingSampleProvider?  _mixer;
 
-    // Per-player state (keyed by ghostId byte)
-    private readonly ConcurrentDictionary<byte, BufferedWaveProvider> _buffers = new();
-    private readonly ConcurrentDictionary<byte, VolumeSampleProvider> _volumes = new();
+    // Per-player state (keyed by ghostId)
+    private readonly ConcurrentDictionary<uint, BufferedWaveProvider> _buffers = new();
+    private readonly ConcurrentDictionary<uint, VolumeSampleProvider> _volumes = new();
 
     // Positions (updated from outside)
-    private readonly ConcurrentDictionary<byte, (float x, float y, float z)> _ghostPos = new();
+    private readonly ConcurrentDictionary<uint, (float x, float y, float z)> _ghostPos = new();
     public (float x, float y, float z) LocalPos { get; set; }
 
     public bool Muted { get; set; } = false;
@@ -131,7 +131,7 @@ public sealed class VoiceChat : IDisposable
     // -------------------------------------------------------------------------
 
     /// <summary>Called when a voice frame arrives from a remote player.</summary>
-    public void OnVoiceReceived(byte sourceId, byte[] pcm)
+    public void OnVoiceReceived(uint sourceId, byte[] pcm)
     {
         if (!_running) return;
 
@@ -156,14 +156,14 @@ public sealed class VoiceChat : IDisposable
     }
 
     /// <summary>Update the 3D position of a remote player's ghost for proximity volume.</summary>
-    public void UpdateGhostPos(byte ghostId, float x, float y, float z)
+    public void UpdateGhostPos(uint ghostId, float x, float y, float z)
     {
         _ghostPos[ghostId] = (x, y, z);
         ApplyVolume(ghostId);
     }
 
     /// <summary>Remove a player — silence and discard their audio pipeline.</summary>
-    public void RemovePlayer(byte ghostId)
+    public void RemovePlayer(uint ghostId)
     {
         _ghostPos.TryRemove(ghostId, out _);
         if (_volumes.TryRemove(ghostId, out var vol))
@@ -178,7 +178,7 @@ public sealed class VoiceChat : IDisposable
             ApplyVolume(id);
     }
 
-    private void ApplyVolume(byte ghostId)
+    private void ApplyVolume(uint ghostId)
     {
         if (!_volumes.TryGetValue(ghostId, out var vol)) return;
 

--- a/dotnet/KcdMp.MasterServer/Features/Announce/AnnounceValidator.cs
+++ b/dotnet/KcdMp.MasterServer/Features/Announce/AnnounceValidator.cs
@@ -42,8 +42,8 @@ internal static class AnnounceValidator
 	private const int MaxAddressLength = 253;
 
 	/// <summary>
-	/// The relay addresses ghosts by a single byte and reserves none of it, so
-	/// no relay can hold more than this however it is configured.
+	/// Defensive public-listing cap. Ghost ids are wider, but this keeps bogus
+	/// announcements from advertising impractical player counts.
 	/// </summary>
 	private const int MaxPlayerLimit = 255;
 
@@ -101,7 +101,7 @@ internal static class AnnounceValidator
 
 		var maxPlayers = Math.Clamp(announce.MaxPlayers, 0, MaxPlayerLimit);
 		if (maxPlayers != announce.MaxPlayers)
-			warnings.Add($"maxPlayers was clamped to {maxPlayers}; a relay cannot address more than {MaxPlayerLimit} players");
+			warnings.Add($"maxPlayers was clamped to the public listing limit of {MaxPlayerLimit}");
 
 		var players = Math.Clamp(announce.Players, 0, maxPlayers);
 

--- a/dotnet/KcdMp.Protocol/Protocol.cs
+++ b/dotnet/KcdMp.Protocol/Protocol.cs
@@ -12,24 +12,24 @@ namespace KcdMp.Wire;
 ///                          flags bit 0: isRiding
 /// C→S  0x04  Ping:       [timestamp:8 LE int64]
 /// C→S  0x07  Voice:      [pcm:640]  (16 kHz mono 16-bit, 20 ms frame)
-/// S→C  0x02  Ghost:      [ghostId:1][x:4f][y:4f][z:4f][rotZ:4f][flags:1]  (18 bytes)
-/// S→C  0x03  Name:       [ghostId:1][name:UTF-8]
+/// S→C  0x02  Ghost:      [ghostId:4 LE uint32][x:4f][y:4f][z:4f][rotZ:4f][flags:1]  (21 bytes)
+/// S→C  0x03  Name:       [ghostId:4 LE uint32][name:UTF-8]
 /// S→C  0x05  Pong:       [timestamp:8 LE int64]  (echo of Ping)
-/// S→C  0x06  Disconnect: [ghostId:1]
-/// S→C  0x08  Voice:      [sourceId:1][pcm:640]
+/// S→C  0x06  Disconnect: [ghostId:4 LE uint32]
+/// S→C  0x08  Voice:      [sourceId:4 LE uint32][pcm:640]
 /// S→C  0x09  VersionMismatch: [serverVersion:1]
-/// S→C  0xFF  Ack:        [assignedId:1]
+/// S→C  0xFF  Ack:        [assignedId:4 LE uint32]
 ///
 /// Interaction layer (WO-2). Opt-in paired interactions: one player invites,
 /// the other accepts or declines, both enter a session the relay arbitrates,
 /// both leave. Dice (WO-5) and duelling are clients of this rather than
 /// separate protocols.
-/// C→S  0x0A  Invite:         [targetGhostId:1][kind:1][configLen:1][config:configLen]
-/// S→C  0x0B  InviteReceived: [sessionId:2][fromGhostId:1][kind:1]
+/// C→S  0x0A  Invite:         [targetGhostId:4 LE uint32][kind:1][configLen:1][config:configLen]
+/// S→C  0x0B  InviteReceived: [sessionId:2][fromGhostId:4 LE uint32][kind:1]
 /// C→S  0x0C  InviteResponse: [sessionId:2][accept:1]
-/// S→C  0x0D  SessionStart:   [sessionId:2][peerGhostId:1][kind:1][role:1]
+/// S→C  0x0D  SessionStart:   [sessionId:2][peerGhostId:4 LE uint32][kind:1][role:1]
 /// C→S  0x0E  SessionEvent:   [sessionId:2][payload:N]
-/// S→C  0x0F  SessionEvent:   [sessionId:2][fromGhostId:1][payload:N]
+/// S→C  0x0F  SessionEvent:   [sessionId:2][fromGhostId:4 LE uint32][payload:N]
 /// C→S  0x10  SessionLeave:   [sessionId:2][reason:1]
 /// S→C  0x11  SessionEnd:     [sessionId:2][reason:1]
 ///
@@ -38,8 +38,7 @@ namespace KcdMp.Wire;
 /// change without touching the session framing.
 ///
 /// [configLen:1][config:configLen] on Invite is new in WO-5 and optional: a
-/// 2-byte Invite (no config) is still valid, matching the WO-2 wire exactly,
-/// so the presence layer and old test scripts needed no changes. It carries
+/// An Invite containing only target id + kind (no config trailer) is valid. It carries
 /// kind-specific open-time settings the same way SessionEvent carries
 /// kind-specific in-play events -- opaque to this layer, interpreted only by
 /// whichever kind reads it. Dice's config is
@@ -58,9 +57,9 @@ namespace KcdMp.Wire;
 ///
 /// Combat layer (WO-4). Replicates damage and death against shared NPCs.
 /// C→S  0x12  Damage: [targetGuid:16][stamina:4f][health:4f][flags:1]  (25 bytes)
-/// S→C  0x13  Damage: [sourceGhostId:1][targetGuid:16][stamina:4f][health:4f][flags:1]  (26)
+/// S→C  0x13  Damage: [sourceGhostId:4 LE uint32][targetGuid:16][stamina:4f][health:4f][flags:1]  (29)
 /// C→S  0x14  Death:  [targetGuid:16]  (16 bytes)
-/// S→C  0x15  Death:  [sourceGhostId:1][targetGuid:16]  (17 bytes)
+/// S→C  0x15  Death:  [sourceGhostId:4 LE uint32][targetGuid:16]  (20 bytes)
 ///                      flags bit 0: suppressHitReaction
 ///
 /// targetGuid is the NPC's SharedSoulGuid, in the same 16-byte order the game
@@ -133,7 +132,7 @@ namespace KcdMp.Wire;
 /// player's currently-equipped clothing/armor AND weapons onto their ghost,
 /// per item, instead of the single hardcoded spawn-time preset.
 /// C→S  0x1A  AppearanceUp:   [itemCount:1][itemClass:16]*itemCount
-/// S→C  0x1B  AppearanceDown: [sourceGhostId:1][itemCount:1][itemClass:16]*itemCount
+/// S→C  0x1B  AppearanceDown: [sourceGhostId:4 LE uint32][itemCount:1][itemClass:16]*itemCount
 ///
 /// itemClass is the item's ItemClass GUID (the game's per-type id, e.g. every
 /// "GambesonShort01_m04_D2" shares one), read from
@@ -168,7 +167,7 @@ namespace KcdMp.Wire;
 /// (HANDOFF-WO4-combat.md), so a player sitting in a menu stops advancing
 /// relative to a peer who is not.
 /// C→S  0x1C  PauseUp:   [state:1]                       (1 byte)
-/// S→C  0x1D  PauseDown: [sourceGhostId:1][state:1]       (2 bytes)
+/// S→C  0x1D  PauseDown: [sourceGhostId:4 LE uint32][state:1]       (5 bytes)
 ///
 /// state: 1 = entered a pausing-like UI state, 0 = exited. Sent on every
 /// transition, not on a timer -- unlike Appearance there is no heartbeat,
@@ -211,7 +210,7 @@ namespace KcdMp.Wire;
 ///      [version][nameLen][name] and never looks past it, so a new client's
 ///      extra bytes are silently ignored rather than breaking the parse.
 ///      A new relay talking to an old client simply finds nothing there.
-/// S→C  0x1E  ReleaseVersion: [ghostId:1][releaseVersion:UTF-8]  -- no
+/// S→C  0x1E  ReleaseVersion: [ghostId:4 LE uint32][releaseVersion:UTF-8]  -- no
 ///      explicit length field, exactly like Name (0x03): the outer
 ///      [type][payloadLen] framing already carries it. Broadcast to existing
 ///      peers when a client's Handshake carried one (mirrors BroadcastName),
@@ -236,7 +235,7 @@ namespace KcdMp.Wire;
 /// even in principle. Players are addressed by ghostId here instead.
 ///
 /// C→S  0x1F  PlayerStateUp:   [health:4f][stamina:4f][flags:1]              (9)
-/// S→C  0x20  PlayerStateDown: [ghostId:1][health:4f][stamina:4f][flags:1]   (10)
+/// S→C  0x20  PlayerStateDown: [ghostId:4 LE uint32][health:4f][stamina:4f][flags:1]   (13)
 ///              flags bit 0: isUnconscious
 ///                   bit 1: isBleeding
 ///
@@ -253,7 +252,7 @@ namespace KcdMp.Wire;
 /// authoritative on that player's own machine (Rule 1), and it is the only
 /// rule that cannot produce a disagreement which fails to self-correct.
 ///
-/// C→S  0x21  PlayerHitUp:   [targetGhostId:1][health:4f][stamina:4f][flags:1]  (10)
+/// C→S  0x21  PlayerHitUp:   [targetGhostId:4 LE uint32][health:4f][stamina:4f][flags:1]  (13)
 /// S→C  0x22  PlayerHitDown: [health:4f][stamina:4f][flags:1]                   (9)
 ///
 /// Flow B, an NPC hurt a player. health/stamina are *loss amounts* (positive
@@ -271,7 +270,7 @@ namespace KcdMp.Wire;
 /// it is that one.
 ///
 /// C→S  0x23  PlayerDeathUp:   []                    (0) -- "I died"
-/// S→C  0x24  PlayerDeathDown: [ghostId:1]           (1)
+/// S→C  0x24  PlayerDeathDown: [ghostId:4 LE uint32]           (4)
 ///
 /// Flow C, a player died. Sent by the dying player's own client (Rule 1) and
 /// never inferred by a peer from health reaching zero, for exactly the reason
@@ -306,7 +305,7 @@ namespace KcdMp.Wire;
 /// ---- NPC sync layer (WO-32) ----
 ///
 /// C→S  0x26  NpcStateUp:   [nameLen:1][name:UTF-8][x:4f][y:4f][z:4f][rotZ:4f][health:4f][flags:1]
-/// S→C  0x27  NpcStateDown: [sourceGhostId:1] + the upstream body verbatim
+/// S→C  0x27  NpcStateDown: [sourceGhostId:4 LE uint32] + the upstream body verbatim
 ///                            flags bit 0: dead in the authority's world
 ///                                 bit 1: knocked out in the authority's world (WO-38 Phase 6)
 ///
@@ -372,7 +371,7 @@ namespace KcdMp.Wire;
 /// ---- Time-skip sync layer (WO-38 Phase 1) ----
 ///
 /// C→S  0x28  TimeSkipUp:   [phase:1][kind:1][worldTime:4 LE uint32]                  (6)
-/// S→C  0x29  TimeSkipDown: [sourceGhostId:1][phase:1][kind:1][worldTime:4 LE uint32] (7)
+/// S→C  0x29  TimeSkipDown: [sourceGhostId:4 LE uint32][phase:1][kind:1][worldTime:4 LE uint32] (10)
 ///
 /// Synchronises the day/night clock across players -- the WO-38 report's
 /// Section F: a player who sleeps to midnight leaves every peer still in
@@ -436,7 +435,7 @@ namespace KcdMp.Wire;
 /// ---- Horse identity layer (WO-38 Phase 5) ----
 ///
 /// C→S  0x2A  HorseInfoUp:   [nameLen:1][name:UTF-8]                  (1 + nameLen)
-/// S→C  0x2B  HorseInfoDown: [sourceGhostId:1][nameLen:1][name:UTF-8] (2 + nameLen)
+/// S→C  0x2B  HorseInfoDown: [sourceGhostId:4 LE uint32][nameLen:1][name:UTF-8] (5 + nameLen)
 ///
 /// Which world horse the sending player is currently riding, by entity name
 /// -- the same cross-client key as the NPC sync layer, valid for the same
@@ -463,7 +462,7 @@ namespace KcdMp.Wire;
 /// ---- Combat visibility layer (WO-39 Phase 1) ----
 ///
 /// C→S  0x2C  CombatEventUp:   [event:1]                    (1)
-/// S→C  0x2D  CombatEventDown: [sourceGhostId:1][event:1]   (2)
+/// S→C  0x2D  CombatEventDown: [sourceGhostId:4 LE uint32][event:1]   (5)
 ///
 /// The WO-38 report's Phase 4 gap: the emit line carries position, rotation,
 /// riding/sneaking flags, health, stamina, dead, unconscious -- and NOTHING
@@ -495,7 +494,7 @@ namespace KcdMp.Wire;
 /// ---- Weather sync layer (WO-40 Phase 3) ----
 ///
 /// C→S  0x2E  WeatherUp:   [nameLen:1][profileName utf8][blendSec:2]                  (var)
-/// S→C  0x2F  WeatherDown: [sourceGhostId:1][nameLen:1][profileName utf8][blendSec:2] (var)
+/// S→C  0x2F  WeatherDown: [sourceGhostId:4 LE uint32][nameLen:1][profileName utf8][blendSec:2] (var)
 ///
 /// The 2026-08-18 footage: "Weather is not synced at all... for PA it is
 /// sunny, for PB it is foggy." The engine exposes a write
@@ -519,7 +518,7 @@ namespace KcdMp.Wire;
 /// ---- Name-addressed NPC damage layer (WO-40 Phase 5) ----
 ///
 /// C→S  0x30  NpcDamageUp:   [nameLen:1][name][stamina:4f][health:4f][flags:1]                  (var)
-/// S→C  0x31  NpcDamageDown: [sourceGhostId:1][nameLen:1][name][stamina:4f][health:4f][flags:1] (var)
+/// S→C  0x31  NpcDamageDown: [sourceGhostId:4 LE uint32][nameLen:1][name][stamina:4f][health:4f][flags:1] (var)
 ///
 /// WO-39 Phase 3 proved the 0x12 wire guid is the per-save Soul Guid, not
 /// SharedSoulGuid, and flagged cross-install stability as the open premise.
@@ -539,9 +538,9 @@ namespace KcdMp.Wire;
 /// ---- Dropped-item sync layer (WO-48) ----
 ///
 /// C→S  0x32  ItemDropUp:   [dropId:4 LE][itemClass:16][amount:2 LE][health:4f][x:4f][y:4f][z:4f]  (38)
-/// S→C  0x33  ItemDropDown: [sourceGhostId:1] + the upstream body verbatim                          (39)
+/// S→C  0x33  ItemDropDown: [sourceGhostId:4 LE uint32] + the upstream body verbatim                  (42)
 /// C→S  0x34  ItemClaimUp:  [dropId:4 LE]                                                            (4)
-/// S→C  0x35  ItemClaimDown:[claimerGhostId:1][dropId:4 LE]                                          (5)
+/// S→C  0x35  ItemClaimDown:[claimerGhostId:4 LE uint32][dropId:4 LE]                                 (8)
 ///
 /// A player deliberately dropping an item for another player is direct
 /// interaction, so it is shared; chests and NPC pockets stay per-player on
@@ -608,14 +607,14 @@ public static class Protocol
     /// <summary>
     /// Protocol version, negotiated in the Handshake.
     ///
-    /// Bumped to 6 for the pause-mitigation layer. The relay refuses any
+    /// Bumped to 7 for 32-bit player/ghost identifiers. The relay refuses any
     /// handshake version that isn't an exact match, so a peer that is
     /// actually connected always speaks the relay's own pause vocabulary --
     /// there is no separate "does the peer support this" gate to add on top
     /// of that, because a peer that didn't would never have gotten past
     /// Handshake.
     /// </summary>
-    public const byte Version = 6;
+    public const byte Version = 7;
 
     // C→S
     public const byte Handshake      = 0x00;
@@ -679,8 +678,11 @@ public static class Protocol
     /// <summary>Exact Position (0x01) payload length.</summary>
     public const int PositionPayloadLen = 17;
 
+    /// <summary>Length of every player/ghost identifier on the wire.</summary>
+    public const int GhostIdLen = sizeof(uint);
+
     /// <summary>Exact Ghost (0x02) payload length.</summary>
-    public const int GhostPayloadLen = 18;
+    public const int GhostPayloadLen = GhostIdLen + PositionPayloadLen;
 
     /// <summary>Exact voice frame length: 20 ms of 16 kHz mono 16-bit PCM.</summary>
     public const int VoiceFrameLen = 640;
@@ -692,13 +694,13 @@ public static class Protocol
     public const int DamageUpPayloadLen = SoulGuidLen + 4 + 4 + 1;
 
     /// <summary>Exact Damage (0x13) downstream payload length.</summary>
-    public const int DamageDownPayloadLen = 1 + DamageUpPayloadLen;
+    public const int DamageDownPayloadLen = GhostIdLen + DamageUpPayloadLen;
 
     /// <summary>Exact Death (0x14) upstream payload length.</summary>
     public const int DeathUpPayloadLen = SoulGuidLen;
 
     /// <summary>Exact Death (0x15) downstream payload length.</summary>
-    public const int DeathDownPayloadLen = 1 + SoulGuidLen;
+    public const int DeathDownPayloadLen = GhostIdLen + SoulGuidLen;
 
     /// <summary>Damage flag: apply without playing a hit reaction.</summary>
     public const byte DamageFlagSuppressHitReaction = 0x01;
@@ -707,7 +709,7 @@ public static class Protocol
     public const int PauseUpPayloadLen = 1;
 
     /// <summary>Exact PauseDown (0x1D) payload length.</summary>
-    public const int PauseDownPayloadLen = 2;
+    public const int PauseDownPayloadLen = GhostIdLen + PauseUpPayloadLen;
 
     /// <summary>PauseUp/PauseDown state byte: entered a pausing-like UI state.</summary>
     public const byte PauseStateEntered = 1;
@@ -745,10 +747,10 @@ public static class Protocol
     public const int PlayerStateUpPayloadLen = 4 + 4 + 1;
 
     /// <summary>Exact PlayerStateDown (0x20) payload length.</summary>
-    public const int PlayerStateDownPayloadLen = 1 + PlayerStateUpPayloadLen;
+    public const int PlayerStateDownPayloadLen = GhostIdLen + PlayerStateUpPayloadLen;
 
     /// <summary>Exact PlayerHitUp (0x21) payload length.</summary>
-    public const int PlayerHitUpPayloadLen = 1 + 4 + 4 + 1;
+    public const int PlayerHitUpPayloadLen = GhostIdLen + 4 + 4 + 1;
 
     /// <summary>Exact PlayerHitDown (0x22) payload length.</summary>
     public const int PlayerHitDownPayloadLen = 4 + 4 + 1;
@@ -757,7 +759,7 @@ public static class Protocol
     public const int PlayerDeathUpPayloadLen = 0;
 
     /// <summary>Exact PlayerDeathDown (0x24) payload length.</summary>
-    public const int PlayerDeathDownPayloadLen = 1;
+    public const int PlayerDeathDownPayloadLen = GhostIdLen;
 
     /// <summary>Exact CombatRole (0x25) payload length.</summary>
     public const int CombatRolePayloadLen = 1;
@@ -885,7 +887,7 @@ public static class Protocol
     public const int TimeSkipUpPayloadLen = 1 + 1 + 4;
 
     /// <summary>Exact TimeSkipDown (0x29) payload length.</summary>
-    public const int TimeSkipDownPayloadLen = 1 + TimeSkipUpPayloadLen;
+    public const int TimeSkipDownPayloadLen = GhostIdLen + TimeSkipUpPayloadLen;
 
     /// <summary>TimeSkip phase: a skip began (no time yet -- worldTime is 0).</summary>
     public const byte TimeSkipPhaseStart = 0;
@@ -960,7 +962,7 @@ public static class Protocol
     public const int CombatEventUpPayloadLen = 1;
 
     /// <summary>Exact CombatEventDown (0x2D) payload length.</summary>
-    public const int CombatEventDownPayloadLen = 2;
+    public const int CombatEventDownPayloadLen = GhostIdLen + CombatEventUpPayloadLen;
 
     /// <summary>Combat event: the sender drew their weapon. Receivers call the ghost's DrawWeapon.</summary>
     public const byte CombatEventWeaponDrawn = 0;
@@ -1015,13 +1017,13 @@ public static class Protocol
     public const int ItemDropUpPayloadLen = 4 + ItemClassLen + 2 + 4 + 4 + 4 + 4;
 
     /// <summary>Exact ItemDropDown (0x33) payload length.</summary>
-    public const int ItemDropDownPayloadLen = 1 + ItemDropUpPayloadLen;
+    public const int ItemDropDownPayloadLen = GhostIdLen + ItemDropUpPayloadLen;
 
     /// <summary>Exact ItemClaimUp (0x34) payload length.</summary>
     public const int ItemClaimUpPayloadLen = 4;
 
     /// <summary>Exact ItemClaimDown (0x35) payload length.</summary>
-    public const int ItemClaimDownPayloadLen = 1 + ItemClaimUpPayloadLen;
+    public const int ItemClaimDownPayloadLen = GhostIdLen + ItemClaimUpPayloadLen;
 
     /// <summary>
     /// How often the dropping agent re-sends a still-unclaimed drop, so a

--- a/dotnet/KcdMp.Server/Features/ClientHandling/ClientHandler.cs
+++ b/dotnet/KcdMp.Server/Features/ClientHandling/ClientHandler.cs
@@ -132,14 +132,14 @@ public class ClientHandler
 	// Deliberately NOT tied to Rule 2's damage authority: any player's sleep
 	// counts (WO-38 spec), so this layer has its own first-come arbitration.
 
-	private byte? _skipOwnerId;
+	private uint? _skipOwnerId;
 	private DateTime _skipStartedUtc;
-	private readonly HashSet<byte> _skipJoined = [];
+	private readonly HashSet<uint> _skipJoined = [];
 
 	// Grace record of the most recently cleared skip, so a joined client
 	// whose own vanilla skip resolves shortly *after* the owner's still gets
 	// its result forwarded quietly rather than announced as a second skip.
-	private HashSet<byte>? _lastSkipJoined;
+	private HashSet<uint>? _lastSkipJoined;
 	private DateTime _lastSkipClearedUtc;
 
 	/// <summary>What the relay should do with an inbound TimeSkipUp.</summary>
@@ -269,7 +269,7 @@ public class ClientHandler
 	// expiry, disconnect clear, and reclaim all destroy it with the entry, so
 	// a new claimant's first packet is never speed-checked against a previous
 	// owner's data -- it seeds a fresh baseline instead.
-	private readonly Dictionary<string, (byte OwnerId, DateTime LastUtc, DateTime EngagedUtc, float X, float Y, float Z)> _npcClaims = [];
+	private readonly Dictionary<string, (uint OwnerId, DateTime LastUtc, DateTime EngagedUtc, float X, float Y, float Z)> _npcClaims = [];
 
 	/// <summary>How <see cref="RouteNpcState"/> disposed of one NpcStateUp.</summary>
 	public enum NpcRoute

--- a/dotnet/KcdMp.Server/Features/ClientHandling/ClientSession.cs
+++ b/dotnet/KcdMp.Server/Features/ClientHandling/ClientSession.cs
@@ -14,7 +14,7 @@ namespace KcdMp.Server.Features.ClientHandling;
 /// </summary>
 public class ClientSession
 {
-    private static int _idCounter;
+    private static long _idCounter;
 
     private readonly ILogger _logger;
     private readonly TcpClient _tcp;
@@ -25,13 +25,13 @@ public class ClientSession
     private const int MaxQueuedPackets = 512;
     private readonly object _writeQueueLock = new();
     private readonly Queue<QueuedWrite> _writeQueue = new();
-    private readonly Dictionary<byte, byte[]> _pendingGhostPackets = new();
+    private readonly Dictionary<uint, byte[]> _pendingGhostPackets = new();
     private readonly SemaphoreSlim _writeSignal = new(0);
     private bool _writeQueueStopped;
 
-    private readonly record struct QueuedWrite(byte[]? Packet, byte? GhostId);
+    private readonly record struct QueuedWrite(byte[]? Packet, uint? GhostId);
 
-    public byte Id { get; } = (byte)Interlocked.Increment(ref _idCounter);
+    public uint Id { get; } = checked((uint)Interlocked.Increment(ref _idCounter));
     public string? Name { get; private set; }
     public bool IsReady => Name is not null;
 
@@ -118,7 +118,7 @@ public class ClientSession
                 Name, Id, clientVersion, ReleaseVersion ?? "(none)", _tcp.Client.RemoteEndPoint);
 
             // Send Ack with assigned ID
-            EnqueueRaw(BuildPacket(Protocol.Ack, [Id]));
+            EnqueueRaw(BuildPacket(Protocol.Ack, EncodeGhostId(Id)));
 
             // Broadcast this client's name to all others; send existing names to this client
             _broadcastService.BroadcastName(this);
@@ -503,28 +503,26 @@ public class ClientSession
     }
 
     /// <summary>Thread-safe: enqueue a Ghost packet to be sent to this client.</summary>
-    public void EnqueueGhost(byte ghostId, float x, float y, float z, float rotZ, byte flags)
+    public void EnqueueGhost(uint ghostId, float x, float y, float z, float rotZ, byte flags)
     {
-        var payload = new byte[18];
-        payload[0] = ghostId;
-        WriteFloat(payload, 1, x);
-        WriteFloat(payload, 5, y);
-        WriteFloat(payload, 9, z);
-        WriteFloat(payload, 13, rotZ);
-        payload[17] = flags;
+        var payload = new byte[Protocol.GhostPayloadLen];
+        BinaryPrimitives.WriteUInt32LittleEndian(payload, ghostId);
+        WriteFloat(payload, Protocol.GhostIdLen, x);
+        WriteFloat(payload, Protocol.GhostIdLen + 4, y);
+        WriteFloat(payload, Protocol.GhostIdLen + 8, z);
+        WriteFloat(payload, Protocol.GhostIdLen + 12, rotZ);
+        payload[Protocol.GhostIdLen + 16] = flags;
         EnqueueGhostPacket(ghostId, BuildPacket(Protocol.Ghost, payload));
     }
 
     /// <summary>Thread-safe: enqueue a Disconnect packet (0x06) to be sent to this client.</summary>
-    public void EnqueueDisconnect(byte ghostId) =>
-        EnqueueRaw(BuildPacket(Protocol.Disconnect, [ghostId]));
+    public void EnqueueDisconnect(uint ghostId) =>
+        EnqueueRaw(BuildPacket(Protocol.Disconnect, EncodeGhostId(ghostId)));
 
     /// <summary>Thread-safe: enqueue a Voice packet (0x08) to be sent to this client.</summary>
-    public void EnqueueVoice(byte sourceId, byte[] pcm)
+    public void EnqueueVoice(uint sourceId, byte[] pcm)
     {
-        var payload = new byte[1 + pcm.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(pcm, 0, payload, 1, pcm.Length);
+        var payload = PrefixGhostId(sourceId, pcm);
         EnqueueRaw(BuildPacket(Protocol.VoiceDown, payload));
     }
 
@@ -532,20 +530,16 @@ public class ClientSession
     /// Thread-safe: enqueue a Damage (0x13) packet to be sent to this client.
     /// The body is the upstream payload verbatim, prefixed with who sent it.
     /// </summary>
-    public void EnqueueDamage(byte sourceId, byte[] upstreamBody)
+    public void EnqueueDamage(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.DamageDown, payload));
     }
 
     /// <summary>Thread-safe: enqueue a Death (0x15) packet to be sent to this client.</summary>
-    public void EnqueueDeath(byte sourceId, byte[] soulGuid)
+    public void EnqueueDeath(uint sourceId, byte[] soulGuid)
     {
-        var payload = new byte[1 + soulGuid.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(soulGuid, 0, payload, 1, soulGuid.Length);
+        var payload = PrefixGhostId(sourceId, soulGuid);
         EnqueueRaw(BuildPacket(Protocol.DeathDown, payload));
     }
 
@@ -554,11 +548,9 @@ public class ClientSession
     /// client. The body is the upstream [itemCount][itemClass...] payload
     /// verbatim, prefixed with who sent it.
     /// </summary>
-    public void EnqueueAppearance(byte sourceId, byte[] upstreamBody)
+    public void EnqueueAppearance(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.AppearanceDown, payload));
     }
 
@@ -567,11 +559,9 @@ public class ClientSession
     /// client. The body is the upstream [state:1] payload verbatim, prefixed
     /// with who sent it.
     /// </summary>
-    public void EnqueuePause(byte sourceId, byte[] upstreamBody)
+    public void EnqueuePause(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.PauseDown, payload));
     }
 
@@ -583,11 +573,9 @@ public class ClientSession
     /// Thread-safe: enqueue a PlayerStateDown (0x20). The body is the upstream
     /// [health][stamina][flags] payload verbatim, prefixed with whose health it is.
     /// </summary>
-    public void EnqueuePlayerState(byte sourceId, byte[] upstreamBody)
+    public void EnqueuePlayerState(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.PlayerStateDown, payload));
     }
 
@@ -596,11 +584,9 @@ public class ClientSession
     /// upstream payload (with the phase byte possibly rewritten to done-quiet
     /// by the routing rules), prefixed with who sent it.
     /// </summary>
-    public void EnqueueTimeSkip(byte sourceId, byte[] upstreamBody)
+    public void EnqueueTimeSkip(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.TimeSkipDown, payload));
     }
 
@@ -608,11 +594,9 @@ public class ClientSession
     /// Thread-safe: enqueue a CombatEventDown (0x2D, WO-39 Phase 1). The body
     /// is the upstream [event:1] payload verbatim, prefixed with who sent it.
     /// </summary>
-    public void EnqueueCombatEvent(byte sourceId, byte[] upstreamBody)
+    public void EnqueueCombatEvent(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.CombatEventDown, payload));
     }
 
@@ -620,11 +604,9 @@ public class ClientSession
     /// Thread-safe: enqueue an NpcDamageDown (0x31, WO-40 Phase 5). The body
     /// is the upstream payload verbatim, prefixed with who sent it.
     /// </summary>
-    public void EnqueueNpcDamage(byte sourceId, byte[] upstreamBody)
+    public void EnqueueNpcDamage(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.NpcDamageDown, payload));
     }
 
@@ -632,11 +614,9 @@ public class ClientSession
     /// Thread-safe: enqueue an ItemDropDown (0x33, WO-48). The body is the
     /// upstream payload verbatim, prefixed with who dropped it.
     /// </summary>
-    public void EnqueueItemDrop(byte sourceId, byte[] upstreamBody)
+    public void EnqueueItemDrop(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.ItemDropDown, payload));
     }
 
@@ -646,11 +626,9 @@ public class ClientSession
     /// other Down packet this one also goes back to its own sender -- the
     /// echo is the claim's confirmation (see Protocol's 0x34 notes).
     /// </summary>
-    public void EnqueueItemClaim(byte claimerId, byte[] upstreamBody)
+    public void EnqueueItemClaim(uint claimerId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = claimerId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(claimerId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.ItemClaimDown, payload));
     }
 
@@ -658,11 +636,9 @@ public class ClientSession
     /// Thread-safe: enqueue a WeatherDown (0x2F, WO-40 Phase 3). The body is
     /// the upstream payload verbatim, prefixed with who sent it.
     /// </summary>
-    public void EnqueueWeather(byte sourceId, byte[] upstreamBody)
+    public void EnqueueWeather(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.WeatherDown, payload));
     }
 
@@ -670,11 +646,9 @@ public class ClientSession
     /// Thread-safe: enqueue a HorseInfoDown (0x2B, WO-38 Phase 5). The body is
     /// the upstream payload verbatim, prefixed with who sent it.
     /// </summary>
-    public void EnqueueHorseInfo(byte sourceId, byte[] upstreamBody)
+    public void EnqueueHorseInfo(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.HorseInfoDown, payload));
     }
 
@@ -682,11 +656,9 @@ public class ClientSession
     /// Thread-safe: enqueue an NpcStateDown (0x27, WO-32). The body is the
     /// upstream payload verbatim, prefixed with who sent it.
     /// </summary>
-    public void EnqueueNpcState(byte sourceId, byte[] upstreamBody)
+    public void EnqueueNpcState(uint sourceId, byte[] upstreamBody)
     {
-        var payload = new byte[1 + upstreamBody.Length];
-        payload[0] = sourceId;
-        Buffer.BlockCopy(upstreamBody, 0, payload, 1, upstreamBody.Length);
+        var payload = PrefixGhostId(sourceId, upstreamBody);
         EnqueueRaw(BuildPacket(Protocol.NpcStateDown, payload));
     }
 
@@ -698,13 +670,13 @@ public class ClientSession
     public void EnqueuePlayerHit(byte[] upstreamBody)
     {
         var payload = new byte[Protocol.PlayerHitDownPayloadLen];
-        Buffer.BlockCopy(upstreamBody, 1, payload, 0, Protocol.PlayerHitDownPayloadLen);
+        Buffer.BlockCopy(upstreamBody, Protocol.GhostIdLen, payload, 0, Protocol.PlayerHitDownPayloadLen);
         EnqueueRaw(BuildPacket(Protocol.PlayerHitDown, payload));
     }
 
     /// <summary>Thread-safe: enqueue a PlayerDeathDown (0x24). Idempotent at the receiver.</summary>
-    public void EnqueuePlayerDeath(byte sourceId) =>
-        EnqueueRaw(BuildPacket(Protocol.PlayerDeathDown, [sourceId]));
+    public void EnqueuePlayerDeath(uint sourceId) =>
+        EnqueueRaw(BuildPacket(Protocol.PlayerDeathDown, EncodeGhostId(sourceId)));
 
     /// <summary>
     /// Thread-safe: enqueue a CombatRole (0x25) telling this client whether it
@@ -779,8 +751,8 @@ public class ClientSession
     {
         switch (type)
         {
-            case Protocol.Invite when body.Length >= 2:
-                _sessions.Invite(this, body[0], (InteractionKind)body[1], _clientHandler, ReadOpenConfig(body));
+            case Protocol.Invite when body.Length >= Protocol.GhostIdLen + 1:
+                _sessions.Invite(this, ReadUInt32(body, 0), (InteractionKind)body[Protocol.GhostIdLen], _clientHandler, ReadOpenConfig(body));
                 break;
 
             case Protocol.InviteResponse when body.Length >= 3:
@@ -812,36 +784,36 @@ public class ClientSession
     /// invitee can see kind-specific open-time settings (e.g. dice's wager)
     /// before answering, not just after accepting.
     /// </summary>
-    public void EnqueueInviteReceived(ushort sessionId, byte fromGhostId, InteractionKind kind, byte[]? config = null)
+    public void EnqueueInviteReceived(ushort sessionId, uint fromGhostId, InteractionKind kind, byte[]? config = null)
     {
         config ??= [];
-        var payload = new byte[5 + config.Length];
+        var payload = new byte[2 + Protocol.GhostIdLen + 2 + config.Length];
         BinaryPrimitives.WriteUInt16LittleEndian(payload, sessionId);
-        payload[2] = fromGhostId;
-        payload[3] = (byte)kind;
-        payload[4] = (byte)config.Length;
-        config.CopyTo(payload, 5);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(2), fromGhostId);
+        payload[2 + Protocol.GhostIdLen] = (byte)kind;
+        payload[3 + Protocol.GhostIdLen] = (byte)config.Length;
+        config.CopyTo(payload, 4 + Protocol.GhostIdLen);
         EnqueueRaw(BuildPacket(Protocol.InviteReceived, payload));
     }
 
     /// <summary>Thread-safe: enqueue a SessionStart (0x0D).</summary>
-    public void EnqueueSessionStart(ushort sessionId, byte peerGhostId, InteractionKind kind, SessionRole role)
+    public void EnqueueSessionStart(ushort sessionId, uint peerGhostId, InteractionKind kind, SessionRole role)
     {
-        var payload = new byte[5];
+        var payload = new byte[2 + Protocol.GhostIdLen + 2];
         BinaryPrimitives.WriteUInt16LittleEndian(payload, sessionId);
-        payload[2] = peerGhostId;
-        payload[3] = (byte)kind;
-        payload[4] = (byte)role;
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(2), peerGhostId);
+        payload[2 + Protocol.GhostIdLen] = (byte)kind;
+        payload[3 + Protocol.GhostIdLen] = (byte)role;
         EnqueueRaw(BuildPacket(Protocol.SessionStart, payload));
     }
 
     /// <summary>Thread-safe: enqueue a SessionEvent (0x0F) from the peer.</summary>
-    public void EnqueueSessionEvent(ushort sessionId, byte fromGhostId, byte[] eventPayload)
+    public void EnqueueSessionEvent(ushort sessionId, uint fromGhostId, byte[] eventPayload)
     {
-        var payload = new byte[3 + eventPayload.Length];
+        var payload = new byte[2 + Protocol.GhostIdLen + eventPayload.Length];
         BinaryPrimitives.WriteUInt16LittleEndian(payload, sessionId);
-        payload[2] = fromGhostId;
-        eventPayload.CopyTo(payload, 3);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(2), fromGhostId);
+        eventPayload.CopyTo(payload, 2 + Protocol.GhostIdLen);
         EnqueueRaw(BuildPacket(Protocol.SessionEventDown, payload));
     }
 
@@ -857,38 +829,39 @@ public class ClientSession
     private static ushort ReadUInt16(byte[] buf, int offset) =>
         BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(offset));
 
+    private static uint ReadUInt32(byte[] buf, int offset) =>
+        BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(offset));
+
     /// <summary>
     /// Extracts an Invite's optional [configLen:1][config:configLen] tail.
-    /// Absent (a bare 2-byte Invite, the pre-WO-5 shape) or truncated both
+    /// Absent (an Invite containing only id + kind) or truncated both
     /// yield an empty config rather than throwing -- a short/garbled config
     /// is the interaction kind's problem to reject, not a reason to drop the
     /// whole Invite.
     /// </summary>
     private static byte[] ReadOpenConfig(byte[] body)
     {
-        if (body.Length < 3) return [];
-        int configLen = body[2];
-        if (body.Length < 3 + configLen) return [];
-        return body[3..(3 + configLen)];
+        int configLenOffset = Protocol.GhostIdLen + 1;
+        if (body.Length <= configLenOffset) return [];
+        int configLen = body[configLenOffset];
+        int configOffset = configLenOffset + 1;
+        if (body.Length < configOffset + configLen) return [];
+        return body[configOffset..(configOffset + configLen)];
     }
 
     /// <summary>Thread-safe: enqueue a Name packet (0x03) to be sent to this client.</summary>
-    public void EnqueueName(byte ghostId, string name)
+    public void EnqueueName(uint ghostId, string name)
     {
         var nameBytes = Encoding.UTF8.GetBytes(name);
-        var payload = new byte[1 + nameBytes.Length];
-        payload[0] = ghostId;
-        nameBytes.CopyTo(payload, 1);
+        var payload = PrefixGhostId(ghostId, nameBytes);
         EnqueueRaw(BuildPacket(Protocol.Name, payload));
     }
 
     /// <summary>Thread-safe: enqueue a ReleaseVersion packet (0x1E, WO-19) to be sent to this client.</summary>
-    public void EnqueueReleaseVersion(byte ghostId, string releaseVersion)
+    public void EnqueueReleaseVersion(uint ghostId, string releaseVersion)
     {
         var verBytes = Encoding.UTF8.GetBytes(releaseVersion);
-        var payload = new byte[1 + verBytes.Length];
-        payload[0] = ghostId;
-        verBytes.CopyTo(payload, 1);
+        var payload = PrefixGhostId(ghostId, verBytes);
         EnqueueRaw(BuildPacket(Protocol.ReleaseVersion, payload));
     }
 
@@ -906,7 +879,7 @@ public class ClientSession
         else _writeSignal.Release();
     }
 
-    private void EnqueueGhostPacket(byte ghostId, byte[] packet)
+    private void EnqueueGhostPacket(uint ghostId, byte[] packet)
     {
         bool overflow;
         bool queued = false;
@@ -969,7 +942,7 @@ public class ClientSession
                 if (_writeQueue.Count > 0)
                 {
                     var queued = _writeQueue.Dequeue();
-                    if (queued.GhostId is byte ghostId)
+                    if (queued.GhostId is uint ghostId)
                     {
                         _pendingGhostPackets.Remove(ghostId, out packet);
                     }
@@ -1003,6 +976,21 @@ public class ClientSession
     }
 
     // ---- Helpers ----
+
+    private static byte[] EncodeGhostId(uint ghostId)
+    {
+        var payload = new byte[Protocol.GhostIdLen];
+        BinaryPrimitives.WriteUInt32LittleEndian(payload, ghostId);
+        return payload;
+    }
+
+    private static byte[] PrefixGhostId(uint ghostId, byte[] body)
+    {
+        var payload = new byte[Protocol.GhostIdLen + body.Length];
+        BinaryPrimitives.WriteUInt32LittleEndian(payload, ghostId);
+        body.CopyTo(payload, Protocol.GhostIdLen);
+        return payload;
+    }
 
     private static byte[] BuildPacket(byte type, byte[] payload)
     {

--- a/dotnet/KcdMp.Server/Features/Interactions/SessionManager.cs
+++ b/dotnet/KcdMp.Server/Features/Interactions/SessionManager.cs
@@ -73,7 +73,7 @@ public class SessionManager
 	/// Handles an Invite. Returns the created session, or null when it was
 	/// refused — in which case the caller has already been told why.
 	/// </summary>
-	public Session? Invite(ClientSession from, byte targetId, InteractionKind kind, ClientHandler clients, byte[] openConfig)
+	public Session? Invite(ClientSession from, uint targetId, InteractionKind kind, ClientHandler clients, byte[] openConfig)
 	{
 		if (!Enum.IsDefined(kind))
 		{

--- a/dotnet/KcdMp.Server/Features/Tcp/TcpBroadcastService.cs
+++ b/dotnet/KcdMp.Server/Features/Tcp/TcpBroadcastService.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using KcdMp.Server.Features.ClientHandling;
 
 namespace KcdMp.Server.Features.Tcp;
@@ -234,7 +235,7 @@ public class TcpBroadcastService
     /// </summary>
     public void RoutePlayerHit(ClientSession source, byte[] body)
     {
-        byte targetId = body[0];
+        uint targetId = BinaryPrimitives.ReadUInt32LittleEndian(body);
         if (targetId == source.Id) return;
 
         foreach (var target in _clientHandler.GetClients())


### PR DESCRIPTION
Note: Make sure to test this change before using it.

Switch player/ghost identifiers from 8-bit to 32-bit across client, server and protocol; bump Protocol.Version to 7 and add Protocol.GhostIdLen=4. Update wire framing, payload lengths, parsing and builders accordingly (many GameBridge, ClientSession, InteractionClient, VoiceChat, TcpBroadcastService, VersionIpcServer, launcher models, etc.). Add AsyncLogger (non-blocking console output + summaries) and wire it into GameBridge. Minor validator/message polish in AnnounceValidator. These changes enable larger player counts and avoid id-space limits.